### PR TITLE
PR: Syncing Subresources

### DIFF
--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: robolaunchio/robot-controller-manager-dev
-  newTag: platform-v0.3.22
+  newTag: platform-v0.3.32

--- a/internal/resources/discovery_server.go
+++ b/internal/resources/discovery_server.go
@@ -87,34 +87,20 @@ func GetDiscoveryServerService(discoveryServer *robotv1alpha1.DiscoveryServer, s
 
 func GetDiscoveryServerConfigMap(discoveryServer *robotv1alpha1.DiscoveryServer, cmNamespacedName *types.NamespacedName) (*corev1.ConfigMap, error) {
 
-	// dnsName := GetDiscoveryServerDNS(*discoveryServer)
-
-	// ips, err := net.LookupIP(dnsName)
-	// if err != nil {
-	// 	return nil, &robotErr.CannotResolveDiscoveryServerError{
-	// 		ResourceKind:      discoveryServer.Kind,
-	// 		ResourceName:      discoveryServer.Name,
-	// 		ResourceNamespace: discoveryServer.Namespace,
-	// 	}
-	// } else if len(ips) == 0 {
-	// 	return nil, &robotErr.CannotResolveDiscoveryServerError{
-	// 		ResourceKind:      discoveryServer.Kind,
-	// 		ResourceName:      discoveryServer.Name,
-	// 		ResourceNamespace: discoveryServer.Namespace,
-	// 	}
-	// }
-
 	superClientConfig := fmt.Sprintf(internal.SUPER_CLIENT_CONFIG, discoveryServer.Status.PodStatus.IP)
 
 	discoveryServerConfigMap := corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      cmNamespacedName.Name,
 			Namespace: cmNamespacedName.Namespace,
+			Labels: map[string]string{
+				"configuredIP": discoveryServer.Status.ConnectionInfo.IP,
+			},
 		},
 		Data: map[string]string{
 			"DISCOVERY_SERVER_CONFIG":        superClientConfig,
 			"FASTRTPS_DEFAULT_PROFILES_FILE": "/etc/discovery-server/super_client_configuration_file.xml",
-			"ROS_DISCOVERY_SERVER":           discoveryServer.Status.ConnectionInfo.IP + ":11811",
+			"ROS_DISCOVERY_SERVER":           discoveryServer.Status.PodStatus.IP + ":11811",
 		},
 	}
 

--- a/pkg/controllers/robot/check.go
+++ b/pkg/controllers/robot/check.go
@@ -2,6 +2,7 @@ package robot
 
 import (
 	"context"
+	"reflect"
 
 	robotv1alpha1 "github.com/robolaunch/robot-operator/api/v1alpha1"
 	batchv1 "k8s.io/api/batch/v1"
@@ -71,6 +72,15 @@ func (r *RobotReconciler) reconcileCheckDiscoveryServer(ctx context.Context, ins
 	} else if err != nil {
 		return err
 	} else {
+
+		if !reflect.DeepEqual(instance.Spec.DiscoveryServerTemplate, discoverServerQuery.Spec) {
+			discoverServerQuery.Spec = instance.Spec.DiscoveryServerTemplate
+			err = r.Update(ctx, discoverServerQuery)
+			if err != nil {
+				return err
+			}
+		}
+
 		instance.Status.DiscoveryServerStatus.Created = true
 		instance.Status.DiscoveryServerStatus.Status = discoverServerQuery.Status
 	}
@@ -112,6 +122,15 @@ func (r *RobotReconciler) reconcileCheckROSBridge(ctx context.Context, instance 
 		} else if err != nil {
 			return err
 		} else {
+
+			if !reflect.DeepEqual(instance.Spec.ROSBridgeTemplate, rosBridgeQuery.Spec) {
+				rosBridgeQuery.Spec = instance.Spec.ROSBridgeTemplate
+				err = r.Update(ctx, rosBridgeQuery)
+				if err != nil {
+					return err
+				}
+			}
+
 			instance.Status.ROSBridgeStatus.Created = true
 			instance.Status.ROSBridgeStatus.Status = rosBridgeQuery.Status
 		}

--- a/pkg/controllers/robot/discovery_server/check.go
+++ b/pkg/controllers/robot/discovery_server/check.go
@@ -72,7 +72,7 @@ func (r *DiscoveryServerReconciler) reconcileUpdateConnectionInfo(ctx context.Co
 			}
 		}
 
-		instance.Status.ConnectionInfo.IP = string(ips[0])
+		instance.Status.ConnectionInfo.IP = ips[0].String()
 		instance.Status.ConnectionInfo.ConfigMapName = instance.GetDiscoveryServerConfigMapMetadata().Name
 	} else {
 		instance.Status.ConnectionInfo = robotv1alpha1.ConnectionInfo{}

--- a/pkg/controllers/robot/discovery_server/check.go
+++ b/pkg/controllers/robot/discovery_server/check.go
@@ -9,48 +9,8 @@ import (
 	"github.com/robolaunch/robot-operator/internal/resources"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
-
-func (r *DiscoveryServerReconciler) reconcileCheckOwnedResources(ctx context.Context, instance *robotv1alpha1.DiscoveryServer) error {
-
-	if instance.Spec.Attached {
-
-		discoveryServerServiceQuery := &corev1.Service{}
-		err := r.Get(ctx, *instance.GetDiscoveryServerServiceMetadata(), discoveryServerServiceQuery)
-		if err != nil && errors.IsNotFound(err) {
-			instance.Status.ServiceStatus.Created = false
-		} else if err != nil {
-			return err
-		} else {
-			instance.Status.ServiceStatus.Created = true
-		}
-
-		discoveryServerPodQuery := &corev1.Pod{}
-		err = r.Get(ctx, *instance.GetDiscoveryServerPodMetadata(), discoveryServerPodQuery)
-		if err != nil && errors.IsNotFound(err) {
-			instance.Status.PodStatus.Created = false
-		} else if err != nil {
-			return err
-		} else {
-			instance.Status.PodStatus.Created = true
-			instance.Status.PodStatus.IP = discoveryServerPodQuery.Status.PodIP
-			instance.Status.PodStatus.Phase = discoveryServerPodQuery.Status.Phase
-		}
-
-	}
-
-	discoveryServerConfigMapQuery := &corev1.ConfigMap{}
-	err := r.Get(ctx, *instance.GetDiscoveryServerConfigMapMetadata(), discoveryServerConfigMapQuery)
-	if err != nil && errors.IsNotFound(err) {
-		instance.Status.ConfigMapStatus.Created = false
-	} else if err != nil {
-		return err
-	} else {
-		instance.Status.ConfigMapStatus.Created = true
-	}
-
-	return nil
-}
 
 func (r *DiscoveryServerReconciler) reconcileUpdateConnectionInfo(ctx context.Context, instance *robotv1alpha1.DiscoveryServer) error {
 
@@ -76,6 +36,118 @@ func (r *DiscoveryServerReconciler) reconcileUpdateConnectionInfo(ctx context.Co
 		instance.Status.ConnectionInfo.ConfigMapName = instance.GetDiscoveryServerConfigMapMetadata().Name
 	} else {
 		instance.Status.ConnectionInfo = robotv1alpha1.ConnectionInfo{}
+	}
+
+	return nil
+}
+
+func (r *DiscoveryServerReconciler) reconcileCheckPod(ctx context.Context, instance *robotv1alpha1.DiscoveryServer) error {
+
+	if instance.Spec.Attached {
+		discoveryServerPodQuery := &corev1.Pod{}
+		err := r.Get(ctx, *instance.GetDiscoveryServerPodMetadata(), discoveryServerPodQuery)
+		if err != nil && errors.IsNotFound(err) {
+			instance.Status.PodStatus.Created = false
+		} else if err != nil {
+			return err
+		} else {
+
+			if discoveryServerPodQuery.Spec.Hostname != instance.Spec.Hostname || discoveryServerPodQuery.Spec.Subdomain != instance.GetDiscoveryServerServiceMetadata().Name {
+				err = r.Delete(ctx, discoveryServerPodQuery)
+				if err != nil {
+					return err
+				}
+
+				instance.Status.PodStatus.IP = ""
+				instance.Status.PodStatus.Phase = ""
+				instance.Status.Phase = ""
+
+			} else {
+
+				instance.Status.PodStatus.Created = true
+				instance.Status.PodStatus.IP = discoveryServerPodQuery.Status.PodIP
+				instance.Status.PodStatus.Phase = discoveryServerPodQuery.Status.Phase
+
+			}
+
+		}
+	}
+
+	return nil
+}
+
+func (r *DiscoveryServerReconciler) reconcileCheckService(ctx context.Context, instance *robotv1alpha1.DiscoveryServer) error {
+
+	if instance.Spec.Attached {
+
+		err := r.reconcileCleanupOwnedServices(ctx, instance)
+		if err != nil {
+			return err
+		}
+
+		discoveryServerServiceQuery := &corev1.Service{}
+		err = r.Get(ctx, *instance.GetDiscoveryServerServiceMetadata(), discoveryServerServiceQuery)
+		if err != nil && errors.IsNotFound(err) {
+			instance.Status.ServiceStatus.Created = false
+		} else if err != nil {
+			return err
+		} else {
+			instance.Status.ServiceStatus.Created = true
+		}
+
+	}
+
+	return nil
+}
+
+func (r *DiscoveryServerReconciler) reconcileCleanupOwnedServices(ctx context.Context, instance *robotv1alpha1.DiscoveryServer) error {
+
+	// service cleanup
+	services := &corev1.ServiceList{}
+	err := r.List(ctx, services, &client.ListOptions{Namespace: instance.Namespace})
+	if err != nil {
+		return err
+	}
+
+	for _, svc := range services.Items {
+		for _, owner := range svc.OwnerReferences {
+			if owner.Name == instance.Name && svc.Name != instance.GetDiscoveryServerServiceMetadata().Name {
+				err := r.Delete(ctx, &svc)
+				if err != nil {
+					return err
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+func (r *DiscoveryServerReconciler) reconcileCheckConfigMap(ctx context.Context, instance *robotv1alpha1.DiscoveryServer) error {
+
+	discoveryServerConfigMapQuery := &corev1.ConfigMap{}
+	err := r.Get(ctx, *instance.GetDiscoveryServerConfigMapMetadata(), discoveryServerConfigMapQuery)
+	if err != nil && errors.IsNotFound(err) {
+		instance.Status.ConfigMapStatus.Created = false
+	} else if err != nil {
+		return err
+	} else {
+
+		if configuredIP, ok := discoveryServerConfigMapQuery.Labels["configuredIP"]; !ok {
+			err := r.Delete(ctx, discoveryServerConfigMapQuery)
+			if err != nil {
+				return err
+			}
+		} else {
+			if configuredIP != instance.Status.PodStatus.IP {
+				err := r.Delete(ctx, discoveryServerConfigMapQuery)
+				if err != nil {
+					return err
+				}
+			}
+		}
+
+		instance.Status.ConfigMapStatus.Created = true
 	}
 
 	return nil

--- a/pkg/controllers/robot/discovery_server/discoveryserver_controller.go
+++ b/pkg/controllers/robot/discovery_server/discoveryserver_controller.go
@@ -57,11 +57,6 @@ func (r *DiscoveryServerReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		return ctrl.Result{}, err
 	}
 
-	err = r.reconcileUpdateConnectionInfo(ctx, instance)
-	if err != nil {
-		return ctrl.Result{}, err
-	}
-
 	err = r.reconcileCheckStatus(ctx, instance)
 	if err != nil {
 		return ctrl.Result{}, err
@@ -73,6 +68,11 @@ func (r *DiscoveryServerReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	}
 
 	err = r.reconcileCheckResources(ctx, instance)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	err = r.reconcileUpdateConnectionInfo(ctx, instance)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -166,7 +166,17 @@ func (r *DiscoveryServerReconciler) reconcileCheckStatus(ctx context.Context, in
 
 func (r *DiscoveryServerReconciler) reconcileCheckResources(ctx context.Context, instance *robotv1alpha1.DiscoveryServer) error {
 
-	err := r.reconcileCheckOwnedResources(ctx, instance)
+	err := r.reconcileCheckService(ctx, instance)
+	if err != nil {
+		return err
+	}
+
+	err = r.reconcileCheckPod(ctx, instance)
+	if err != nil {
+		return err
+	}
+
+	err = r.reconcileCheckConfigMap(ctx, instance)
 	if err != nil {
 		return err
 	}
@@ -180,5 +190,6 @@ func (r *DiscoveryServerReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		For(&robotv1alpha1.DiscoveryServer{}).
 		Owns(&corev1.Pod{}).
 		Owns(&corev1.Service{}).
+		Owns(&corev1.ConfigMap{}).
 		Complete(r)
 }

--- a/pkg/controllers/robot/ros_bridge/check.go
+++ b/pkg/controllers/robot/ros_bridge/check.go
@@ -4,11 +4,12 @@ import (
 	"context"
 
 	robotv1alpha1 "github.com/robolaunch/robot-operator/api/v1alpha1"
+	"github.com/robolaunch/robot-operator/internal/resources"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 )
 
-func (r *ROSBridgeReconciler) reconcileCheckOwnedResources(ctx context.Context, instance *robotv1alpha1.ROSBridge) error {
+func (r *ROSBridgeReconciler) reconcileCheckService(ctx context.Context, instance *robotv1alpha1.ROSBridge) error {
 
 	bridgeServiceQuery := &corev1.Service{}
 	err := r.Get(ctx, *instance.GetBridgeServiceMetadata(), bridgeServiceQuery)
@@ -20,13 +21,46 @@ func (r *ROSBridgeReconciler) reconcileCheckOwnedResources(ctx context.Context, 
 		instance.Status.ServiceStatus.Created = true
 	}
 
+	return nil
+}
+
+func (r *ROSBridgeReconciler) reconcileCheckPod(ctx context.Context, instance *robotv1alpha1.ROSBridge) error {
+
 	bridgePodQuery := &corev1.Pod{}
-	err = r.Get(ctx, *instance.GetBridgePodMetadata(), bridgePodQuery)
+	err := r.Get(ctx, *instance.GetBridgePodMetadata(), bridgePodQuery)
 	if err != nil && errors.IsNotFound(err) {
 		instance.Status.PodStatus = robotv1alpha1.BridgePodStatus{}
 	} else if err != nil {
 		return err
 	} else {
+
+		rosBridgeFound := false
+		ros2BridgeFound := false
+		rightImage := true
+		for _, container := range bridgePodQuery.Spec.Containers {
+			if container.Name == resources.ROS_BRIDGE_PORT_NAME {
+				rosBridgeFound = true
+			}
+			if container.Name == resources.ROS2_BRIDGE_PORT_NAME {
+				ros2BridgeFound = true
+			}
+			if instance.Spec.Image != container.Image {
+				rightImage = false
+			}
+		}
+
+		if (!rosBridgeFound && instance.Spec.ROS.Enabled) ||
+			(!ros2BridgeFound && instance.Spec.ROS2.Enabled) ||
+			!rightImage {
+			err = r.Delete(ctx, bridgePodQuery)
+			if err != nil {
+				return err
+			}
+
+			instance.Status.PodStatus.Phase = ""
+			return nil
+		}
+
 		instance.Status.PodStatus.Created = true
 		instance.Status.PodStatus.Phase = bridgePodQuery.Status.Phase
 	}

--- a/pkg/controllers/robot/ros_bridge/check.go
+++ b/pkg/controllers/robot/ros_bridge/check.go
@@ -49,8 +49,8 @@ func (r *ROSBridgeReconciler) reconcileCheckPod(ctx context.Context, instance *r
 			}
 		}
 
-		if (!rosBridgeFound && instance.Spec.ROS.Enabled) ||
-			(!ros2BridgeFound && instance.Spec.ROS2.Enabled) ||
+		if (instance.Spec.ROS.Enabled && !rosBridgeFound) ||
+			(instance.Spec.ROS2.Enabled && !ros2BridgeFound) ||
 			!rightImage {
 			err = r.Delete(ctx, bridgePodQuery)
 			if err != nil {

--- a/pkg/controllers/robot/ros_bridge/rosbridge_controller.go
+++ b/pkg/controllers/robot/ros_bridge/rosbridge_controller.go
@@ -122,7 +122,12 @@ func (r *ROSBridgeReconciler) reconcileCheckStatus(ctx context.Context, instance
 
 func (r *ROSBridgeReconciler) reconcileCheckResources(ctx context.Context, instance *robotv1alpha1.ROSBridge) error {
 
-	err := r.reconcileCheckOwnedResources(ctx, instance)
+	err := r.reconcileCheckService(ctx, instance)
+	if err != nil {
+		return err
+	}
+
+	err = r.reconcileCheckPod(ctx, instance)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
# :herb: PR: Syncing Subresources

## Description

Discovery server and ROS bridge configuration can be handled from robot's API. It's aimed to follow this pattern between resources and subresources.

Closes #11

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How can it be tested?

It can be tested by changing `.spec.discoveryServerTemplate` or `.spec.rosBridgeTemplate` fields of robot when robot is deployed.
