### PR TITLE
PR: Enable Selecting RMW Implementation

### DIFF
--- a/config/crd/bases/robot.roboscale.io_robotartifacts.yaml
+++ b/config/crd/bases/robot.roboscale.io_robotartifacts.yaml
@@ -445,6 +445,13 @@ spec:
                       type: object
                   type: object
                 type: array
+              rmwImplementation:
+                default: rmw_fastrtps_cpp
+                description: RMW implementation selection. Robot operator currently
+                  supports only FastRTPS. See https://docs.ros.org/en/foxy/How-To-Guides/Working-with-multiple-RMW-implementations.html.
+                enum:
+                - rmw_fastrtps_cpp
+                type: string
               robotDevSuiteTemplate:
                 description: Robot development suite template
                 properties:
@@ -660,6 +667,7 @@ spec:
                 type: object
             required:
             - distributions
+            - rmwImplementation
             type: object
         type: object
     served: true

--- a/config/crd/bases/robot.roboscale.io_robots.yaml
+++ b/config/crd/bases/robot.roboscale.io_robots.yaml
@@ -452,6 +452,13 @@ spec:
                       type: object
                   type: object
                 type: array
+              rmwImplementation:
+                default: rmw_fastrtps_cpp
+                description: RMW implementation selection. Robot operator currently
+                  supports only FastRTPS. See https://docs.ros.org/en/foxy/How-To-Guides/Working-with-multiple-RMW-implementations.html.
+                enum:
+                - rmw_fastrtps_cpp
+                type: string
               robotDevSuiteTemplate:
                 description: Robot development suite template
                 properties:
@@ -667,6 +674,7 @@ spec:
                 type: object
             required:
             - distributions
+            - rmwImplementation
             type: object
           status:
             description: RobotStatus defines the observed state of Robot

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: robolaunchio/robot-controller-manager
-  newTag: v0.1.6
+  newTag: v0.1.7

--- a/hack/deploy/robot_operator.yaml
+++ b/hack/deploy/robot_operator.yaml
@@ -1270,6 +1270,12 @@ spec:
                         type: object
                     type: object
                   type: array
+                rmwImplementation:
+                  default: rmw_fastrtps_cpp
+                  description: RMW implementation selection. Robot operator currently supports only FastRTPS. See https://docs.ros.org/en/foxy/How-To-Guides/Working-with-multiple-RMW-implementations.html.
+                  enum:
+                    - rmw_fastrtps_cpp
+                  type: string
                 robotDevSuiteTemplate:
                   description: Robot development suite template
                   properties:
@@ -1473,6 +1479,7 @@ spec:
                   type: object
               required:
                 - distributions
+                - rmwImplementation
               type: object
           type: object
       served: true
@@ -2040,6 +2047,12 @@ spec:
                         type: object
                     type: object
                   type: array
+                rmwImplementation:
+                  default: rmw_fastrtps_cpp
+                  description: RMW implementation selection. Robot operator currently supports only FastRTPS. See https://docs.ros.org/en/foxy/How-To-Guides/Working-with-multiple-RMW-implementations.html.
+                  enum:
+                    - rmw_fastrtps_cpp
+                  type: string
                 robotDevSuiteTemplate:
                   description: Robot development suite template
                   properties:
@@ -2243,6 +2256,7 @@ spec:
                   type: object
               required:
                 - distributions
+                - rmwImplementation
               type: object
             status:
               description: RobotStatus defines the observed state of Robot
@@ -4028,7 +4042,7 @@ spec:
             - --leader-elect
           command:
             - /manager
-          image: robolaunchio/robot-controller-manager:v0.1.6
+          image: robolaunchio/robot-controller-manager:v0.1.7
           livenessProbe:
             httpGet:
               path: /healthz

--- a/internal/configure/rmw_implementation.go
+++ b/internal/configure/rmw_implementation.go
@@ -1,0 +1,27 @@
+package configure
+
+import (
+	"github.com/robolaunch/robot-operator/internal"
+	robotv1alpha1 "github.com/robolaunch/robot-operator/pkg/api/roboscale.io/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func InjectRMWImplementationConfiguration(pod *corev1.Pod, robot robotv1alpha1.Robot) *corev1.Pod {
+
+	placeRMWImplementationEnvironmentVariables(pod, robot)
+
+	return pod
+}
+
+func placeRMWImplementationEnvironmentVariables(pod *corev1.Pod, robot robotv1alpha1.Robot) {
+
+	environmentVariables := []corev1.EnvVar{
+		internal.Env("RMW_IMPLEMENTATION", string(robot.Spec.RMWImplementation)),
+	}
+
+	for k, container := range pod.Spec.Containers {
+		container.Env = append(container.Env, environmentVariables...)
+		pod.Spec.Containers[k] = container
+	}
+
+}

--- a/internal/configure/rmw_implementation.go
+++ b/internal/configure/rmw_implementation.go
@@ -8,13 +8,6 @@ import (
 
 func InjectRMWImplementationConfiguration(pod *corev1.Pod, robot robotv1alpha1.Robot) *corev1.Pod {
 
-	placeRMWImplementationEnvironmentVariables(pod, robot)
-
-	return pod
-}
-
-func placeRMWImplementationEnvironmentVariables(pod *corev1.Pod, robot robotv1alpha1.Robot) {
-
 	environmentVariables := []corev1.EnvVar{
 		internal.Env("RMW_IMPLEMENTATION", string(robot.Spec.RMWImplementation)),
 	}
@@ -24,4 +17,19 @@ func placeRMWImplementationEnvironmentVariables(pod *corev1.Pod, robot robotv1al
 		pod.Spec.Containers[k] = container
 	}
 
+	return pod
+}
+
+func InjectRMWImplementationConfigurationForPodSpec(podSpec *corev1.PodSpec, robot robotv1alpha1.Robot) *corev1.PodSpec {
+
+	environmentVariables := []corev1.EnvVar{
+		internal.Env("RMW_IMPLEMENTATION", string(robot.Spec.RMWImplementation)),
+	}
+
+	for k, container := range podSpec.Containers {
+		container.Env = append(container.Env, environmentVariables...)
+		podSpec.Containers[k] = container
+	}
+
+	return podSpec
 }

--- a/internal/resources/build_manager.go
+++ b/internal/resources/build_manager.go
@@ -89,6 +89,7 @@ func GetBuildJob(buildManager *robotv1alpha1.BuildManager, robot *robotv1alpha1.
 	}
 
 	configure.InjectGenericEnvironmentVariablesForPodSpec(&podSpec, *robot)
+	configure.InjectRMWImplementationConfigurationForPodSpec(&podSpec, *robot)
 
 	job := batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{

--- a/internal/resources/launch_manager.go
+++ b/internal/resources/launch_manager.go
@@ -56,6 +56,7 @@ func GetLaunchPod(launchManager *robotv1alpha1.LaunchManager, podNamespacedName 
 
 	configure.SchedulePod(&launchPod, label.GetTenancyMap(launchManager))
 	configure.InjectGenericEnvironmentVariables(&launchPod, robot)                                                     // Environment variables
+	configure.InjectRMWImplementationConfiguration(&launchPod, robot)                                                  // RMW implementation configuration
 	configure.InjectPodDiscoveryServerConnection(&launchPod, robot.Status.DiscoveryServerStatus.Status.ConnectionInfo) // Discovery server configuration
 	if label.GetTargetRobotVDI(launchManager) != "" {
 		configure.InjectPodDisplayConfiguration(&launchPod, robotVDI) // Display configuration

--- a/internal/resources/robot.go
+++ b/internal/resources/robot.go
@@ -118,9 +118,10 @@ func GetLoaderJob(robot *robotv1alpha1.Robot, jobNamespacedName *types.Namespace
 	clonerCmdBuilder.WriteString("echo \"DONE\"")
 
 	copierContainer := corev1.Container{
-		Name:    "copier",
-		Image:   robot.Status.Image,
-		Command: internal.Bash(copierCmdBuilder.String()),
+		Name:            "copier",
+		Image:           robot.Status.Image,
+		Command:         internal.Bash(copierCmdBuilder.String()),
+		ImagePullPolicy: corev1.PullAlways,
 		VolumeMounts: []corev1.VolumeMount{
 			configure.GetVolumeMount("/ros/", configure.GetVolumeVar(robot)),
 			configure.GetVolumeMount("/ros/", configure.GetVolumeUsr(robot)),
@@ -179,9 +180,10 @@ func GetLoaderJob(robot *robotv1alpha1.Robot, jobNamespacedName *types.Namespace
 		driverInstallerCmdBuilder.WriteString(filepath.Join("/etc", "vdi", "install-driver.sh"))
 
 		driverInstaller := corev1.Container{
-			Name:    "driver-installer",
-			Image:   robot.Status.Image,
-			Command: internal.Bash(driverInstallerCmdBuilder.String()),
+			Name:            "driver-installer",
+			Image:           robot.Status.Image,
+			Command:         internal.Bash(driverInstallerCmdBuilder.String()),
+			ImagePullPolicy: corev1.PullAlways,
 			VolumeMounts: []corev1.VolumeMount{
 				configure.GetVolumeMount("", configure.GetVolumeVar(robot)),
 				configure.GetVolumeMount("", configure.GetVolumeUsr(robot)),

--- a/internal/resources/robot_ide.go
+++ b/internal/resources/robot_ide.go
@@ -85,6 +85,7 @@ func GetRobotIDEPod(robotIDE *robotv1alpha1.RobotIDE, podNamespacedName *types.N
 
 	configure.SchedulePod(&pod, label.GetTenancyMap(robotIDE))
 	configure.InjectGenericEnvironmentVariables(&pod, robot)
+	configure.InjectRMWImplementationConfiguration(&pod, robot)
 	configure.InjectPodDiscoveryServerConnection(&pod, robot.Status.DiscoveryServerStatus.Status.ConnectionInfo)
 	if label.GetTargetRobotVDI(robotIDE) != "" {
 		configure.InjectPodDisplayConfiguration(&pod, robotVDI)

--- a/internal/resources/robot_vdi.go
+++ b/internal/resources/robot_vdi.go
@@ -146,6 +146,7 @@ func GetRobotVDIPod(robotVDI *robotv1alpha1.RobotVDI, podNamespacedName *types.N
 
 	configure.SchedulePod(vdiPod, label.GetTenancyMap(robotVDI))
 	configure.InjectGenericEnvironmentVariables(vdiPod, robot)
+	configure.InjectRMWImplementationConfiguration(vdiPod, robot)
 	configure.InjectPodDiscoveryServerConnection(vdiPod, robot.Status.DiscoveryServerStatus.Status.ConnectionInfo)
 	configure.InjectPodDisplayConfiguration(vdiPod, *robotVDI)
 

--- a/internal/resources/ros_bridge.go
+++ b/internal/resources/ros_bridge.go
@@ -51,6 +51,7 @@ func GetBridgePod(rosbridge *robotv1alpha1.ROSBridge, podNamespacedName *types.N
 
 	configure.SchedulePod(&bridgePod, label.GetTenancyMap(rosbridge))
 	configure.InjectPodDiscoveryServerConnection(&bridgePod, robot.Status.DiscoveryServerStatus.Status.ConnectionInfo)
+	configure.InjectRMWImplementationConfiguration(&bridgePod, robot)
 
 	return &bridgePod
 }

--- a/pkg/api/roboscale.io/v1alpha1/robot_types.go
+++ b/pkg/api/roboscale.io/v1alpha1/robot_types.go
@@ -121,6 +121,21 @@ const (
 	ROSDistroHumble ROSDistro = "humble"
 )
 
+// RMW implementation selection. Robot operator currently supports only FastRTPS. See https://docs.ros.org/en/foxy/How-To-Guides/Working-with-multiple-RMW-implementations.html.
+// +kubebuilder:validation:Enum=rmw_fastrtps_cpp
+type RMWImplementation string
+
+const (
+	// Cyclone DDS
+	RMWImplementationCycloneDDS ROSDistro = "rmw_cyclonedds_cpp"
+	// FastRTPS
+	RMWImplementationFastRTPS ROSDistro = "rmw_fastrtps_cpp"
+	// Connext
+	RMWImplementationConnext ROSDistro = "rmw_connext_cpp"
+	// Gurum DDS
+	RMWImplementationGurumDDS ROSDistro = "rmw_gurumdds_cpp"
+)
+
 // Storage class configuration for a volume type.
 type StorageClassConfig struct {
 	// Storage class name
@@ -160,6 +175,9 @@ type RobotSpec struct {
 	// +kubebuilder:validation:MinItems=1
 	// +kubebuilder:validation:MaxItems=2
 	Distributions []ROSDistro `json:"distributions"`
+	// +kubebuilder:validation:Required
+	// +kubebuilder:default=rmw_fastrtps_cpp
+	RMWImplementation RMWImplementation `json:"rmwImplementation"`
 	// Resource limitations of robot containers.
 	Storage Storage `json:"storage,omitempty"`
 	// Discovery server template


### PR DESCRIPTION
# :herb: PR: Enable Selecting RMW Implementation

## Description

DDS implementation can be selected by setting the field `spec.rmwImplementation` of robot.

Closes #64

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How can it be tested?

It can be tested by setting the field `spec.rmwImplementation` with one of the followings:
- `rmw_cyclonedds_cpp`
- `rmw_fastrtps_cpp`
- `rmw_connext_cpp`
- `rmw_gurumdds_cpp`

Currently, only Fast RTPS is supported.
