### PR TITLE
PR: Support Launches Without Display Configuration

### DIFF
--- a/internal/resources/launch_manager.go
+++ b/internal/resources/launch_manager.go
@@ -58,7 +58,8 @@ func GetLaunchPod(launchManager *robotv1alpha1.LaunchManager, podNamespacedName 
 	configure.InjectGenericEnvironmentVariables(&launchPod, robot)                                                     // Environment variables
 	configure.InjectRMWImplementationConfiguration(&launchPod, robot)                                                  // RMW implementation configuration
 	configure.InjectPodDiscoveryServerConnection(&launchPod, robot.Status.DiscoveryServerStatus.Status.ConnectionInfo) // Discovery server configuration
-	if label.GetTargetRobotVDI(launchManager) != "" {
+	if launchManager.Spec.Display && label.GetTargetRobotVDI(launchManager) != "" {
+		// TODO: Add control for validating robot VDI
 		configure.InjectPodDisplayConfiguration(&launchPod, robotVDI) // Display configuration
 	}
 

--- a/pkg/api/roboscale.io/v1alpha1/manager_types.go
+++ b/pkg/api/roboscale.io/v1alpha1/manager_types.go
@@ -236,13 +236,13 @@ type Launch struct {
 	Privileged bool `json:"privileged,omitempty"`
 	// Launch container resource limits.
 	Resources Resources `json:"resources,omitempty"`
-	// Display connection.
-	Display bool `json:"display,omitempty"`
 }
 
 // LaunchManagerSpec defines the desired state of LaunchManager
 type LaunchManagerSpec struct {
-	Launch map[string]Launch `json:"launch,omitempty"`
+	// Display connection.
+	Display bool              `json:"display,omitempty"`
+	Launch  map[string]Launch `json:"launch,omitempty"`
 }
 
 type LaunchStatus struct {

--- a/pkg/api/roboscale.io/v1alpha1/manager_types.go
+++ b/pkg/api/roboscale.io/v1alpha1/manager_types.go
@@ -236,6 +236,8 @@ type Launch struct {
 	Privileged bool `json:"privileged,omitempty"`
 	// Launch container resource limits.
 	Resources Resources `json:"resources,omitempty"`
+	// Display connection.
+	Display bool `json:"display,omitempty"`
 }
 
 // LaunchManagerSpec defines the desired state of LaunchManager

--- a/pkg/api/roboscale.io/v1alpha1/manager_webhook.go
+++ b/pkg/api/roboscale.io/v1alpha1/manager_webhook.go
@@ -294,8 +294,18 @@ func (r *LaunchManager) checkTargetRobotLabel() error {
 func (r *LaunchManager) checkTargetRobotVDILabel() error {
 	labels := r.GetLabels()
 
-	if _, ok := labels[internal.TARGET_VDI_LABEL_KEY]; !ok {
-		return errors.New("target robot vdi label should be added with key " + internal.TARGET_VDI_LABEL_KEY)
+	needDisplay := false
+	for _, l := range r.Spec.Launch {
+		if l.Display {
+			needDisplay = true
+			break
+		}
+	}
+
+	if needDisplay {
+		if _, ok := labels[internal.TARGET_VDI_LABEL_KEY]; !ok {
+			return errors.New("target robot vdi label should be added with key " + internal.TARGET_VDI_LABEL_KEY)
+		}
 	}
 
 	return nil

--- a/pkg/api/roboscale.io/v1alpha1/manager_webhook.go
+++ b/pkg/api/roboscale.io/v1alpha1/manager_webhook.go
@@ -294,15 +294,7 @@ func (r *LaunchManager) checkTargetRobotLabel() error {
 func (r *LaunchManager) checkTargetRobotVDILabel() error {
 	labels := r.GetLabels()
 
-	needDisplay := false
-	for _, l := range r.Spec.Launch {
-		if l.Display {
-			needDisplay = true
-			break
-		}
-	}
-
-	if needDisplay {
+	if r.Spec.Display {
 		if _, ok := labels[internal.TARGET_VDI_LABEL_KEY]; !ok {
 			return errors.New("target robot vdi label should be added with key " + internal.TARGET_VDI_LABEL_KEY)
 		}


### PR DESCRIPTION
# :herb: PR: Support Launches Without Display Configuration

## Description

Closes #67 

## Type of change

- [x] This change requires a documentation update

## How can it be tested?

It can be tested by creating a launch manager with it's display disabled. (`.spec.display=false`)