### PR TITLE
PR: Remove Display Obligation From IDE

### DIFF
--- a/internal/resources/robot_ide.go
+++ b/internal/resources/robot_ide.go
@@ -87,7 +87,7 @@ func GetRobotIDEPod(robotIDE *robotv1alpha1.RobotIDE, podNamespacedName *types.N
 	configure.InjectGenericEnvironmentVariables(&pod, robot)
 	configure.InjectRMWImplementationConfiguration(&pod, robot)
 	configure.InjectPodDiscoveryServerConnection(&pod, robot.Status.DiscoveryServerStatus.Status.ConnectionInfo)
-	if label.GetTargetRobotVDI(robotIDE) != "" {
+	if robotIDE.Spec.Display && label.GetTargetRobotVDI(robotIDE) != "" {
 		configure.InjectPodDisplayConfiguration(&pod, robotVDI)
 	}
 

--- a/pkg/api/roboscale.io/v1alpha1/dev_types.go
+++ b/pkg/api/roboscale.io/v1alpha1/dev_types.go
@@ -136,6 +136,8 @@ type RobotIDESpec struct {
 	ServiceType corev1.ServiceType `json:"serviceType,omitempty"`
 	Ingress     bool               `json:"ingress,omitempty"`
 	Privileged  bool               `json:"privileged,omitempty"`
+	// Display configuration.
+	Display bool `json:"display,omitempty"`
 }
 
 type RobotIDEPodStatus struct {

--- a/pkg/api/roboscale.io/v1alpha1/dev_webhook.go
+++ b/pkg/api/roboscale.io/v1alpha1/dev_webhook.go
@@ -89,8 +89,10 @@ func (r *RobotIDE) checkTargetRobotLabel() error {
 func (r *RobotIDE) checkTargetRobotVDILabel() error {
 	labels := r.GetLabels()
 
-	if _, ok := labels[internal.TARGET_VDI_LABEL_KEY]; !ok {
-		return errors.New("target robot vdi label should be added with key " + internal.TARGET_VDI_LABEL_KEY)
+	if r.Spec.Display {
+		if _, ok := labels[internal.TARGET_VDI_LABEL_KEY]; !ok {
+			return errors.New("target robot vdi label should be added with key " + internal.TARGET_VDI_LABEL_KEY)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
# :herb: PR: Remove Display Obligation From IDE

## Description

Display configuration is added as an option for IDE.

Closes #69 

## Type of change

- [x] This change requires a documentation update

## How can it be tested?

IDE display configuration can be tested by switching `spec.display` field, `true` and `false`.