### PR TITLE
PR: Add Cluster Selector to Build Manager Steps

### DIFF
--- a/pkg/api/roboscale.io/v1alpha1/manager_types.go
+++ b/pkg/api/roboscale.io/v1alpha1/manager_types.go
@@ -162,6 +162,8 @@ type WorkspaceManagerStatus struct {
 // Step is a command or script to execute when building a robot. Either `command` or `script` should be specified
 // for each step.
 type Step struct {
+	// Cluster selector.
+	Selector map[string]string `json:"selector,omitempty"`
 	// Name of the step.
 	Name string `json:"name"`
 	// Name of the workspace.

--- a/pkg/controllers/build_manager/helpers.go
+++ b/pkg/controllers/build_manager/helpers.go
@@ -97,7 +97,7 @@ func (r *BuildManagerReconciler) reconcileCheckOtherAttachedResources(ctx contex
 
 		for _, rds := range robotDevSuiteList.Items {
 
-			if rds.Status.Active == true {
+			if rds.Status.Active {
 				return &robotErr.RobotResourcesHasNotBeenReleasedError{
 					ResourceKind:      instance.Kind,
 					ResourceName:      instance.Name,
@@ -122,7 +122,7 @@ func (r *BuildManagerReconciler) reconcileCheckOtherAttachedResources(ctx contex
 
 		for _, lm := range launchManagerList.Items {
 
-			if lm.Status.Active == true {
+			if lm.Status.Active {
 				return &robotErr.RobotResourcesHasNotBeenReleasedError{
 					ResourceKind:      instance.Kind,
 					ResourceName:      instance.Name,
@@ -151,7 +151,7 @@ func (r *BuildManagerReconciler) reconcileCheckOtherAttachedResources(ctx contex
 				continue
 			}
 
-			if bm.Status.Active == true {
+			if bm.Status.Active {
 				return &robotErr.RobotResourcesHasNotBeenReleasedError{
 					ResourceKind:      instance.Kind,
 					ResourceName:      instance.Name,


### PR DESCRIPTION
# :herb: PR: Add Cluster Selector to Build Manager Steps

## Description

Build manager now only registers the steps that are assigned on current cluster.

Closes #78 

## Type of change

- [x] This change requires a documentation update

## How can it be tested?

It can be tested by adding selector to any of the steps and use tenancy selectors for cloud instance and physical instance.
