### PR TITLE
PR: Abandon Using `ROS_DISCOVERY_SERVER` Environment Variable

### DIFF
--- a/internal/configure/discovery_server.go
+++ b/internal/configure/discovery_server.go
@@ -27,17 +27,6 @@ func placeDiscoveryServerEnvironmentVariables(pod *corev1.Pod, connectionInfo ro
 				},
 			},
 		},
-		{
-			Name: "ROS_DISCOVERY_SERVER",
-			ValueFrom: &corev1.EnvVarSource{
-				ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
-					LocalObjectReference: corev1.LocalObjectReference{
-						Name: connectionInfo.ConfigMapName,
-					},
-					Key: "ROS_DISCOVERY_SERVER",
-				},
-			},
-		},
 	}
 
 	for k, container := range pod.Spec.Containers {

--- a/internal/resources/discovery_server.go
+++ b/internal/resources/discovery_server.go
@@ -100,7 +100,6 @@ func GetDiscoveryServerConfigMap(discoveryServer *robotv1alpha1.DiscoveryServer,
 		Data: map[string]string{
 			"DISCOVERY_SERVER_CONFIG":        superClientConfig,
 			"FASTRTPS_DEFAULT_PROFILES_FILE": "/etc/discovery-server/super_client_configuration_file.xml",
-			"ROS_DISCOVERY_SERVER":           discoveryServer.Status.ConnectionInfo.IP + ":11811",
 		},
 	}
 


### PR DESCRIPTION
# :herb: PR: Abandon Using `ROS_DISCOVERY_SERVER` Environment Variable

## Description

`ROS_DISCOVERY_SERVER` environment variable is not stored in configmap and injected to workloads.

Closes #84 
