### PR TITLE
PR: Synchronize RobotDevSuite Components

### DIFF
--- a/pkg/api/roboscale.io/v1alpha1/robot_webhook.go
+++ b/pkg/api/roboscale.io/v1alpha1/robot_webhook.go
@@ -68,6 +68,11 @@ func (r *Robot) ValidateCreate() error {
 		return err
 	}
 
+	err = r.checkRobotDevSuite()
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -86,6 +91,11 @@ func (r *Robot) ValidateUpdate(old runtime.Object) error {
 	}
 
 	err = r.checkWorkspaces()
+	if err != nil {
+		return err
+	}
+
+	err = r.checkRobotDevSuite()
 	if err != nil {
 		return err
 	}
@@ -153,6 +163,17 @@ func (r *Robot) checkWorkspaces() error {
 	return nil
 }
 
+func (r *Robot) checkRobotDevSuite() error {
+
+	dst := r.Spec.RobotDevSuiteTemplate
+
+	if dst.IDEEnabled && dst.RobotIDETemplate.Display && !dst.VDIEnabled {
+		return errors.New("cannot open an ide with a display when vdi disabled")
+	}
+
+	return nil
+}
+
 func (r *Robot) setRepositoryInfo() error {
 
 	for k1, ws := range r.Spec.WorkspaceManagerTemplate.Workspaces {
@@ -166,6 +187,10 @@ func (r *Robot) setRepositoryInfo() error {
 			repo.Repo = repoName
 
 			lastCommitHash, err := getLastCommitHash(repo)
+			if err != nil {
+				return err
+			}
+
 			repo.Hash = lastCommitHash
 
 			ws.Repositories[k2] = repo

--- a/pkg/controllers/robot/check.go
+++ b/pkg/controllers/robot/check.go
@@ -149,14 +149,15 @@ func (r *RobotReconciler) reconcileCheckROSBridge(ctx context.Context, instance 
 
 func (r *RobotReconciler) reconcileCheckRobotDevSuite(ctx context.Context, instance *robotv1alpha1.Robot) error {
 
-	if instance.Spec.RobotDevSuiteTemplate.IDEEnabled || instance.Spec.RobotDevSuiteTemplate.VDIEnabled {
-		robotDevSuiteQuery := &robotv1alpha1.RobotDevSuite{}
-		err := r.Get(ctx, *instance.GetRobotDevSuiteMetadata(), robotDevSuiteQuery)
-		if err != nil && errors.IsNotFound(err) {
-			instance.Status.RobotDevSuiteStatus = robotv1alpha1.RobotDevSuiteInstanceStatus{}
-		} else if err != nil {
-			return err
-		} else {
+	robotDevSuiteQuery := &robotv1alpha1.RobotDevSuite{}
+	err := r.Get(ctx, *instance.GetRobotDevSuiteMetadata(), robotDevSuiteQuery)
+	if err != nil && errors.IsNotFound(err) {
+		instance.Status.RobotDevSuiteStatus = robotv1alpha1.RobotDevSuiteInstanceStatus{}
+	} else if err != nil {
+		return err
+	} else {
+
+		if instance.Spec.RobotDevSuiteTemplate.IDEEnabled || instance.Spec.RobotDevSuiteTemplate.VDIEnabled {
 
 			if !reflect.DeepEqual(instance.Spec.RobotDevSuiteTemplate, robotDevSuiteQuery.Spec) {
 				robotDevSuiteQuery.Spec = instance.Spec.RobotDevSuiteTemplate
@@ -168,7 +169,16 @@ func (r *RobotReconciler) reconcileCheckRobotDevSuite(ctx context.Context, insta
 
 			instance.Status.RobotDevSuiteStatus.Created = true
 			instance.Status.RobotDevSuiteStatus.Status = robotDevSuiteQuery.Status
+
+		} else {
+
+			err := r.Delete(ctx, robotDevSuiteQuery)
+			if err != nil {
+				return err
+			}
+
 		}
+
 	}
 
 	return nil

--- a/pkg/controllers/robot_dev_suite/check.go
+++ b/pkg/controllers/robot_dev_suite/check.go
@@ -10,17 +10,17 @@ import (
 
 func (r *RobotDevSuiteReconciler) reconcileCheckRobotVDI(ctx context.Context, instance *robotv1alpha1.RobotDevSuite) error {
 
-	if instance.Spec.VDIEnabled {
-
-		robotVDIQuery := &robotv1alpha1.RobotVDI{}
-		err := r.Get(ctx, *instance.GetRobotVDIMetadata(), robotVDIQuery)
-		if err != nil {
-			if errors.IsNotFound(err) {
-				instance.Status.RobotVDIStatus.Created = false
-			} else {
-				return err
-			}
+	robotVDIQuery := &robotv1alpha1.RobotVDI{}
+	err := r.Get(ctx, *instance.GetRobotVDIMetadata(), robotVDIQuery)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			instance.Status.RobotVDIStatus = robotv1alpha1.RobotVDIInstanceStatus{}
 		} else {
+			return err
+		}
+	} else {
+
+		if instance.Spec.VDIEnabled {
 
 			if !reflect.DeepEqual(instance.Spec.RobotVDITemplate, robotVDIQuery.Spec) {
 				robotVDIQuery.Spec = instance.Spec.RobotVDITemplate
@@ -32,6 +32,14 @@ func (r *RobotDevSuiteReconciler) reconcileCheckRobotVDI(ctx context.Context, in
 
 			instance.Status.RobotVDIStatus.Created = true
 			instance.Status.RobotVDIStatus.Phase = robotVDIQuery.Status.Phase
+
+		} else {
+
+			err := r.Delete(ctx, robotVDIQuery)
+			if err != nil {
+				return err
+			}
+
 		}
 
 	}
@@ -41,17 +49,17 @@ func (r *RobotDevSuiteReconciler) reconcileCheckRobotVDI(ctx context.Context, in
 
 func (r *RobotDevSuiteReconciler) reconcileCheckRobotIDE(ctx context.Context, instance *robotv1alpha1.RobotDevSuite) error {
 
-	if instance.Spec.IDEEnabled {
-
-		robotIDEQuery := &robotv1alpha1.RobotIDE{}
-		err := r.Get(ctx, *instance.GetRobotIDEMetadata(), robotIDEQuery)
-		if err != nil {
-			if errors.IsNotFound(err) {
-				instance.Status.RobotIDEStatus.Created = false
-			} else {
-				return err
-			}
+	robotIDEQuery := &robotv1alpha1.RobotIDE{}
+	err := r.Get(ctx, *instance.GetRobotIDEMetadata(), robotIDEQuery)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			instance.Status.RobotIDEStatus = robotv1alpha1.RobotIDEInstanceStatus{}
 		} else {
+			return err
+		}
+	} else {
+
+		if instance.Spec.IDEEnabled {
 
 			if !reflect.DeepEqual(instance.Spec.RobotIDETemplate, robotIDEQuery.Spec) {
 				robotIDEQuery.Spec = instance.Spec.RobotIDETemplate
@@ -63,6 +71,14 @@ func (r *RobotDevSuiteReconciler) reconcileCheckRobotIDE(ctx context.Context, in
 
 			instance.Status.RobotIDEStatus.Created = true
 			instance.Status.RobotIDEStatus.Phase = robotIDEQuery.Status.Phase
+
+		} else {
+
+			err := r.Delete(ctx, robotIDEQuery)
+			if err != nil {
+				return err
+			}
+
 		}
 
 	}

--- a/pkg/controllers/robot_dev_suite/check.go
+++ b/pkg/controllers/robot_dev_suite/check.go
@@ -2,6 +2,7 @@ package robot_dev_suite
 
 import (
 	"context"
+	"reflect"
 
 	robotv1alpha1 "github.com/robolaunch/robot-operator/pkg/api/roboscale.io/v1alpha1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -20,6 +21,15 @@ func (r *RobotDevSuiteReconciler) reconcileCheckRobotVDI(ctx context.Context, in
 				return err
 			}
 		} else {
+
+			if !reflect.DeepEqual(instance.Spec.RobotVDITemplate, robotVDIQuery.Spec) {
+				robotVDIQuery.Spec = instance.Spec.RobotVDITemplate
+				err = r.Update(ctx, robotVDIQuery)
+				if err != nil {
+					return err
+				}
+			}
+
 			instance.Status.RobotVDIStatus.Created = true
 			instance.Status.RobotVDIStatus.Phase = robotVDIQuery.Status.Phase
 		}
@@ -42,6 +52,15 @@ func (r *RobotDevSuiteReconciler) reconcileCheckRobotIDE(ctx context.Context, in
 				return err
 			}
 		} else {
+
+			if !reflect.DeepEqual(instance.Spec.RobotIDETemplate, robotIDEQuery.Spec) {
+				robotIDEQuery.Spec = instance.Spec.RobotIDETemplate
+				err = r.Update(ctx, robotIDEQuery)
+				if err != nil {
+					return err
+				}
+			}
+
 			instance.Status.RobotIDEStatus.Created = true
 			instance.Status.RobotIDEStatus.Phase = robotIDEQuery.Status.Phase
 		}


### PR DESCRIPTION
# :herb: PR: Synchronize RobotDevSuite Components

## Description

The issue about dynamically opening & closing RobotIDE and RobotVDI is resolved.

Closes #76 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How can it be tested?

It can be tested by switching the `bool` values of robot API `.spec.robotDevSuiteTemplate.ideEnabled` and `.spec.robotDevSuiteTemplate.vdiEnabled`.
