### PR TITLE
PR: Select VDI Resolution

### DIFF
--- a/config/crd/bases/robot.roboscale.io_robotartifacts.yaml
+++ b/config/crd/bases/robot.roboscale.io_robotartifacts.yaml
@@ -702,6 +702,14 @@ spec:
                         type: string
                       privileged:
                         type: boolean
+                      resolution:
+                        default: 1920x1080
+                        description: VDI screen resolution options.
+                        enum:
+                        - 2048x1152
+                        - 1920x1080
+                        - 1600x1200
+                        type: string
                       resources:
                         description: VDI resource limits.
                         properties:

--- a/config/crd/bases/robot.roboscale.io_robotdevsuites.yaml
+++ b/config/crd/bases/robot.roboscale.io_robotdevsuites.yaml
@@ -77,6 +77,14 @@ spec:
                     type: string
                   privileged:
                     type: boolean
+                  resolution:
+                    default: 1920x1080
+                    description: VDI screen resolution options.
+                    enum:
+                    - 2048x1152
+                    - 1920x1080
+                    - 1600x1200
+                    type: string
                   resources:
                     description: VDI resource limits.
                     properties:

--- a/config/crd/bases/robot.roboscale.io_robots.yaml
+++ b/config/crd/bases/robot.roboscale.io_robots.yaml
@@ -709,6 +709,14 @@ spec:
                         type: string
                       privileged:
                         type: boolean
+                      resolution:
+                        default: 1920x1080
+                        description: VDI screen resolution options.
+                        enum:
+                        - 2048x1152
+                        - 1920x1080
+                        - 1600x1200
+                        type: string
                       resources:
                         description: VDI resource limits.
                         properties:

--- a/config/crd/bases/robot.roboscale.io_robotvdis.yaml
+++ b/config/crd/bases/robot.roboscale.io_robotvdis.yaml
@@ -42,6 +42,14 @@ spec:
                 type: string
               privileged:
                 type: boolean
+              resolution:
+                default: 1920x1080
+                description: VDI screen resolution options.
+                enum:
+                - 2048x1152
+                - 1920x1080
+                - 1600x1200
+                type: string
               resources:
                 description: VDI resource limits.
                 properties:

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: robolaunchio/robot-controller-manager-dev
-  newTag: platform-v0.5.94
+  newTag: platform-v0.5.95

--- a/internal/resources/robot_vdi.go
+++ b/internal/resources/robot_vdi.go
@@ -108,6 +108,7 @@ func GetRobotVDIPod(robotVDI *robotv1alpha1.RobotVDI, podNamespacedName *types.N
 						internal.Env("NEKO_UDP_PORT", robotVDI.Spec.WebRTCPortRange),
 						internal.Env("NEKO_ICELITE", icelite),
 						internal.Env("NEKO_NAT1TO1", robotVDI.Spec.NAT1TO1),
+						internal.Env("RESOLUTION", robotVDI.Spec.Resolution),
 					},
 					Stdin: true,
 					TTY:   true,

--- a/pkg/api/roboscale.io/v1alpha1/dev_types.go
+++ b/pkg/api/roboscale.io/v1alpha1/dev_types.go
@@ -189,6 +189,9 @@ type RobotVDISpec struct {
 	// +kubebuilder:validation:Pattern=`^([0-9])+-([0-9])+$`
 	// +kubebuilder:validation:Required
 	WebRTCPortRange string `json:"webrtcPortRange,omitempty"`
+	// VDI screen resolution options.
+	// +kubebuilder:validation:Enum=2048x1152;1920x1080;1600x1200
+	Resolution string `json:"resolution,omitempty"`
 }
 
 type RobotVDIPodStatus struct {

--- a/pkg/api/roboscale.io/v1alpha1/dev_types.go
+++ b/pkg/api/roboscale.io/v1alpha1/dev_types.go
@@ -190,7 +190,8 @@ type RobotVDISpec struct {
 	// +kubebuilder:validation:Required
 	WebRTCPortRange string `json:"webrtcPortRange,omitempty"`
 	// VDI screen resolution options.
-	// +kubebuilder:validation:Enum=2048x1152;1920x1080;1600x1200
+	// +kubebuilder:validation:Enum="2048x1152";"1920x1080";"1600x1200"
+	// +kubebuilder:default="2048x1152"
 	Resolution string `json:"resolution,omitempty"`
 }
 


### PR DESCRIPTION
# :herb: PR: Select VDI Resolution

## Description

VDI resolution can be selected setting the field `spec.resolution` of RobotVDI with the format `2048x1152`.

Closes #97

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How can it be tested?

It can be tested by checking resolution after setting it in API.