### PR TITLE
PR: Update FastDDS Configuration

### DIFF
--- a/docs/ros2/discovery-server/README.md
+++ b/docs/ros2/discovery-server/README.md
@@ -1,0 +1,56 @@
+# Discovery Server Configuration
+
+Here is the FastDDS configuration that provides communications such that
+
+- clients will only consume UDPv4
+- as super client
+- using discovery server
+
+```xml
+<?xml version='1.0' encoding='UTF-8' ?>
+<dds>
+    <profiles
+        xmlns='http://www.eprosima.com/XMLSchemas/fastRTPS_Profiles'>
+        
+        <!-- UDPv4 Transport profile -->
+        <transport_descriptors>
+            <transport_descriptor>
+                <transport_id>udp_transport</transport_id>
+                <type>UDPv4</type>
+            </transport_descriptor>
+        </transport_descriptors>
+        
+        <participant profile_name='super_client_profile' is_default_profile='true'>
+            <rtps>
+                <!-- Use user defined UDPv4 transport -->
+                <userTransports>
+                    <transport_id>udp_transport</transport_id>
+                </userTransports>
+                <!-- Disable builtin transports -->
+                <useBuiltinTransports>false</useBuiltinTransports>
+
+                <!-- Connect to discovery server as SUPER_CLIENT -->
+                <builtin>
+                    <discovery_config>
+                        <discoveryProtocol>SUPER_CLIENT</discoveryProtocol>
+                        <discoveryServersList>
+                            <RemoteServer prefix='44.53.00.5f.45.50.52.4f.53.49.4d.41'>
+                                <metatrafficUnicastLocatorList>
+                                    <locator>
+                                        <udpv4>
+                                            <address>POD_IP</address>
+                                            <port>CONTAINER_PORT</port>
+                                        </udpv4>
+                                    </locator>
+                                </metatrafficUnicastLocatorList>
+                            </RemoteServer>
+                        </discoveryServersList>
+                    </discovery_config>
+                </builtin>
+            </rtps>
+        </participant>
+    </profiles>
+</dds>
+```
+
+This solution is recommended in [FastDDS discussions](https://github.com/eProsima/Fast-DDS/discussions/3262).

--- a/internal/shared.go
+++ b/internal/shared.go
@@ -97,7 +97,11 @@ const (
 		"<dds>" +
 		"<profiles xmlns='http://www.eprosima.com/XMLSchemas/fastRTPS_Profiles'>" +
 		"<participant profile_name='super_client_profile' is_default_profile='true'>" +
-		"<rtps>" +
+		"	<rtps>" +
+		"		<userTransports>" +
+		"			<transport_id>udp_transport</transport_id>" +
+		"		<userTransports>" +
+		"		<useBuiltinTransports>false</useBuiltinTransports>" +
 		"		<builtin>" +
 		"			<discovery_config>" +
 		"				<discoveryProtocol>SUPER_CLIENT</discoveryProtocol>" +

--- a/internal/shared.go
+++ b/internal/shared.go
@@ -93,35 +93,42 @@ const (
 
 // Super client configuration
 const (
-	SUPER_CLIENT_CONFIG = "<?xml version='1.0' encoding='UTF-8' ?>" +
+	SUPER_CLIENT_CONFIG = "" +
+		"<?xml version='1.0' encoding='UTF-8' ?>" +
 		"<dds>" +
-		"<profiles xmlns='http://www.eprosima.com/XMLSchemas/fastRTPS_Profiles'>" +
-		"	<participant profile_name='super_client_profile' is_default_profile='true'>" +
-		"		<rtps>" +
-		"			<userTransports>" +
+		"	<profiles xmlns='http://www.eprosima.com/XMLSchemas/fastRTPS_Profiles'>" +
+		"		<transport_descriptors>" +
+		"			<transport_descriptor>" +
 		"				<transport_id>udp_transport</transport_id>" +
-		"			<userTransports>" +
-		"			<useBuiltinTransports>false</useBuiltinTransports>" +
-		"			<builtin>" +
-		"				<discovery_config>" +
-		"					<discoveryProtocol>SUPER_CLIENT</discoveryProtocol>" +
-		"					<discoveryServersList>" +
-		"						<RemoteServer prefix='44.53.00.5f.45.50.52.4f.53.49.4d.41'>" +
-		"							<metatrafficUnicastLocatorList>" +
-		"								<locator>" +
-		"									<udpv4>" +
-		"									<address>" + "%s" + "</address>" +
-		"										<port>11811</port>" +
-		"									</udpv4>" +
-		"								</locator>" +
-		"							</metatrafficUnicastLocatorList>" +
-		"						</RemoteServer>" +
-		"					</discoveryServersList>" +
-		"				</discovery_config>" +
-		"			</builtin>" +
-		"		</rtps>" +
-		"	</participant>" +
-		"</profiles>" +
+		"				<type>UDPv4</type>" +
+		"			</transport_descriptor>" +
+		"		</transport_descriptors>" +
+		"		<participant profile_name='super_client_profile' is_default_profile='true'>" +
+		"			<rtps>" +
+		"				<userTransports>" +
+		"					<transport_id>udp_transport</transport_id>" +
+		"				</userTransports>" +
+		"				<useBuiltinTransports>false</useBuiltinTransports>" +
+		"				<builtin>" +
+		"					<discovery_config>" +
+		"						<discoveryProtocol>SUPER_CLIENT</discoveryProtocol>" +
+		"						<discoveryServersList>" +
+		"							<RemoteServer prefix='44.53.00.5f.45.50.52.4f.53.49.4d.41'>" +
+		"								<metatrafficUnicastLocatorList>" +
+		"									<locator>" +
+		"										<udpv4>" +
+		"										<address>" + "%s" + "</address>" +
+		"											<port>11811</port>" +
+		"										</udpv4>" +
+		"									</locator>" +
+		"								</metatrafficUnicastLocatorList>" +
+		"							</RemoteServer>" +
+		"						</discoveryServersList>" +
+		"					</discovery_config>" +
+		"				</builtin>" +
+		"			</rtps>" +
+		"		</participant>" +
+		"	</profiles>" +
 		"</dds>"
 )
 

--- a/internal/shared.go
+++ b/internal/shared.go
@@ -96,31 +96,31 @@ const (
 	SUPER_CLIENT_CONFIG = "<?xml version='1.0' encoding='UTF-8' ?>" +
 		"<dds>" +
 		"<profiles xmlns='http://www.eprosima.com/XMLSchemas/fastRTPS_Profiles'>" +
-		"<participant profile_name='super_client_profile' is_default_profile='true'>" +
-		"	<rtps>" +
-		"		<userTransports>" +
-		"			<transport_id>udp_transport</transport_id>" +
-		"		<userTransports>" +
-		"		<useBuiltinTransports>false</useBuiltinTransports>" +
-		"		<builtin>" +
-		"			<discovery_config>" +
-		"				<discoveryProtocol>SUPER_CLIENT</discoveryProtocol>" +
-		"				<discoveryServersList>" +
-		"					<RemoteServer prefix='44.53.00.5f.45.50.52.4f.53.49.4d.41'>" +
-		"						<metatrafficUnicastLocatorList>" +
-		"							<locator>" +
-		"								<udpv4>" +
-		"								<address>" + "%s" + "</address>" +
-		"									<port>11811</port>" +
-		"								</udpv4>" +
-		"							</locator>" +
-		"						</metatrafficUnicastLocatorList>" +
-		"					</RemoteServer>" +
-		"				</discoveryServersList>" +
-		"			</discovery_config>" +
-		"		</builtin>" +
-		"	</rtps>" +
-		"</participant>" +
+		"	<participant profile_name='super_client_profile' is_default_profile='true'>" +
+		"		<rtps>" +
+		"			<userTransports>" +
+		"				<transport_id>udp_transport</transport_id>" +
+		"			<userTransports>" +
+		"			<useBuiltinTransports>false</useBuiltinTransports>" +
+		"			<builtin>" +
+		"				<discovery_config>" +
+		"					<discoveryProtocol>SUPER_CLIENT</discoveryProtocol>" +
+		"					<discoveryServersList>" +
+		"						<RemoteServer prefix='44.53.00.5f.45.50.52.4f.53.49.4d.41'>" +
+		"							<metatrafficUnicastLocatorList>" +
+		"								<locator>" +
+		"									<udpv4>" +
+		"									<address>" + "%s" + "</address>" +
+		"										<port>11811</port>" +
+		"									</udpv4>" +
+		"								</locator>" +
+		"							</metatrafficUnicastLocatorList>" +
+		"						</RemoteServer>" +
+		"					</discoveryServersList>" +
+		"				</discovery_config>" +
+		"			</builtin>" +
+		"		</rtps>" +
+		"	</participant>" +
 		"</profiles>" +
 		"</dds>"
 )


### PR DESCRIPTION
# :herb: PR: Update FastDDS Configuration

## Description

FastDDS configuration is updated by using [recommended solution](https://github.com/eProsima/Fast-DDS/discussions/3262) to satisfy
- only UDPv4 communication
- super client
- discovery server connection

Closes #75

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How can it be tested?

It can be tested by using RPLidar packages. Pod-to-pod communication should be observed while the containers are privileged. (they should transmit `/scan` topic)