### PR TITLE
PR: Open IDE w/ `robolaunch` User

### DIFF
--- a/internal/configure/linux_user.go
+++ b/internal/configure/linux_user.go
@@ -1,0 +1,20 @@
+package configure
+
+import (
+	robotv1alpha1 "github.com/robolaunch/robot-operator/pkg/api/roboscale.io/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func InjectLinuxUserAndGroup(pod *corev1.Pod, robot robotv1alpha1.Robot) *corev1.Pod {
+
+	var user int64 = 1000
+	var group int64 = 3000
+
+	for key, cont := range pod.Spec.Containers {
+		cont.SecurityContext.RunAsUser = &user
+		cont.SecurityContext.RunAsGroup = &group
+		pod.Spec.Containers[key] = cont
+	}
+
+	return pod
+}

--- a/internal/resources/robot_ide.go
+++ b/internal/resources/robot_ide.go
@@ -85,6 +85,7 @@ func GetRobotIDEPod(robotIDE *robotv1alpha1.RobotIDE, podNamespacedName *types.N
 
 	configure.SchedulePod(&pod, label.GetTenancyMap(robotIDE))
 	configure.InjectGenericEnvironmentVariables(&pod, robot)
+	configure.InjectLinuxUserAndGroup(&pod, robot)
 	configure.InjectRMWImplementationConfiguration(&pod, robot)
 	configure.InjectPodDiscoveryServerConnection(&pod, robot.Status.DiscoveryServerStatus.Status.ConnectionInfo)
 	configure.InjectRuntimeClass(&pod, robot, node)


### PR DESCRIPTION
# :herb: PR: Open IDE w/ `robolaunch` User

## Description

- Injection for Linux user & group to pods are added
- IDE is configured to start w/ user `robolaunch`

Closes #131

## Type of change

- [x] This change requires a documentation update

## How can it be tested?

Can be tested by opening a GUI application from IDE terminal.
