### PR TITLE
PR: Check RobotIDE's Owned ServiceExport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 ## [Unreleased]
 
 
+<a name="v0.2.5-alpha.21"></a>
+## [v0.2.5-alpha.21] - 2023-07-04
+### Fix
+- **remote-ide:** update rds operational conditions
+
+
 <a name="v0.2.5-alpha.20"></a>
 ## [v0.2.5-alpha.20] - 2023-06-23
 ### Feat
@@ -151,7 +157,8 @@
 - Merge pull request [#24](https://github.com/robolaunch/robot-operator/issues/24) from robolaunch/23-allow-multiple-launches
 
 
-[Unreleased]: https://github.com/robolaunch/robot-operator/compare/v0.2.5-alpha.20...HEAD
+[Unreleased]: https://github.com/robolaunch/robot-operator/compare/v0.2.5-alpha.21...HEAD
+[v0.2.5-alpha.21]: https://github.com/robolaunch/robot-operator/compare/v0.2.5-alpha.20...v0.2.5-alpha.21
 [v0.2.5-alpha.20]: https://github.com/robolaunch/robot-operator/compare/v0.2.5-alpha.19...v0.2.5-alpha.20
 [v0.2.5-alpha.19]: https://github.com/robolaunch/robot-operator/compare/v0.2.5-alpha.18...v0.2.5-alpha.19
 [v0.2.5-alpha.18]: https://github.com/robolaunch/robot-operator/compare/v0.2.5-alpha.17...v0.2.5-alpha.18

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: robolaunchio/robot-controller-manager
-  newTag: v0.2.5-alpha.21
+  newTag: v0.2.5-alpha.22

--- a/hack/deploy/chart/robot-operator/Chart.yaml
+++ b/hack/deploy/chart/robot-operator/Chart.yaml
@@ -13,9 +13,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.5-alpha.21
+version: 0.2.5-alpha.22
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.2.5-alpha.21"
+appVersion: "v0.2.5-alpha.22"

--- a/hack/deploy/chart/robot-operator/values.yaml
+++ b/hack/deploy/chart/robot-operator/values.yaml
@@ -23,7 +23,7 @@ controllerManager:
         - ALL
     image:
       repository: robolaunchio/robot-controller-manager
-      tag: v0.2.5-alpha.21
+      tag: v0.2.5-alpha.22
     resources:
       limits:
         cpu: 500m

--- a/hack/deploy/manifests/robot_operator.yaml
+++ b/hack/deploy/manifests/robot_operator.yaml
@@ -6937,7 +6937,7 @@ spec:
             - --leader-elect
           command:
             - /manager
-          image: robolaunchio/robot-controller-manager:v0.2.5-alpha.21
+          image: robolaunchio/robot-controller-manager:v0.2.5-alpha.22
           livenessProbe:
             httpGet:
               path: /healthz

--- a/pkg/controllers/robot_dev_suite/robot_ide/check.go
+++ b/pkg/controllers/robot_dev_suite/robot_ide/check.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/robolaunch/robot-operator/internal/handle"
 	"github.com/robolaunch/robot-operator/internal/reference"
+	mcsv1alpha1 "github.com/robolaunch/robot-operator/pkg/api/external/apis/mcsv1alpha1/v1alpha1"
 	robotv1alpha1 "github.com/robolaunch/robot-operator/pkg/api/roboscale.io/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
@@ -81,6 +82,24 @@ func (r *RobotIDEReconciler) reconcileCheckIngress(ctx context.Context, instance
 			instance.Status.IngressStatus.Created = true
 			reference.SetReference(&instance.Status.IngressStatus.Reference, ingressQuery.TypeMeta, ingressQuery.ObjectMeta)
 		}
+	}
+
+	return nil
+}
+
+func (r *RobotIDEReconciler) reconcileCheckServiceExport(ctx context.Context, instance *robotv1alpha1.RobotIDE) error {
+
+	serviceExportQuery := &mcsv1alpha1.ServiceExport{}
+	err := r.Get(ctx, *instance.GetRobotIDEServiceExportMetadata(), serviceExportQuery)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			instance.Status.ServiceExportStatus = robotv1alpha1.OwnedResourceStatus{}
+		} else {
+			return err
+		}
+	} else {
+		instance.Status.ServiceExportStatus.Created = true
+		reference.SetReference(&instance.Status.ServiceExportStatus.Reference, serviceExportQuery.TypeMeta, serviceExportQuery.ObjectMeta)
 	}
 
 	return nil

--- a/pkg/controllers/robot_dev_suite/robot_ide/robotide_controller.go
+++ b/pkg/controllers/robot_dev_suite/robot_ide/robotide_controller.go
@@ -169,6 +169,13 @@ func (r *RobotIDEReconciler) reconcileCheckResources(ctx context.Context, instan
 		return err
 	}
 
+	if label.GetInstanceType(instance) == label.InstanceTypePhysicalInstance {
+		err = r.reconcileCheckServiceExport(ctx, instance)
+		if err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
# :herb: PR: Check RobotIDE's Owned ServiceExport

## Description

Related to https://github.com/robolaunch/connection-hub-operator/issues/67

- ServiceExport is created again if not found in cluster (physical instances)

Closes #143 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How can it be tested?

Can be tested by deleting the resource (ServiceExport) after creation.