### PR TITLE
PR: Check DiscoveryServer IP Every 5 Seconds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 ## [Unreleased]
 
 
+<a name="v0.2.5-alpha.22"></a>
+## [v0.2.5-alpha.22] - 2023-07-07
+### Fix
+- **serviceexport:** check robotide serviceexport resource status
+
+
 <a name="v0.2.5-alpha.21"></a>
 ## [v0.2.5-alpha.21] - 2023-07-04
 ### Fix
@@ -157,7 +163,8 @@
 - Merge pull request [#24](https://github.com/robolaunch/robot-operator/issues/24) from robolaunch/23-allow-multiple-launches
 
 
-[Unreleased]: https://github.com/robolaunch/robot-operator/compare/v0.2.5-alpha.21...HEAD
+[Unreleased]: https://github.com/robolaunch/robot-operator/compare/v0.2.5-alpha.22...HEAD
+[v0.2.5-alpha.22]: https://github.com/robolaunch/robot-operator/compare/v0.2.5-alpha.21...v0.2.5-alpha.22
 [v0.2.5-alpha.21]: https://github.com/robolaunch/robot-operator/compare/v0.2.5-alpha.20...v0.2.5-alpha.21
 [v0.2.5-alpha.20]: https://github.com/robolaunch/robot-operator/compare/v0.2.5-alpha.19...v0.2.5-alpha.20
 [v0.2.5-alpha.19]: https://github.com/robolaunch/robot-operator/compare/v0.2.5-alpha.18...v0.2.5-alpha.19

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: robolaunchio/robot-controller-manager
-  newTag: v0.2.5-alpha.22
+  newTag: v0.2.5-alpha.23

--- a/hack/deploy/chart/robot-operator/Chart.yaml
+++ b/hack/deploy/chart/robot-operator/Chart.yaml
@@ -13,9 +13,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.5-alpha.22
+version: 0.2.5-alpha.23
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.2.5-alpha.22"
+appVersion: "v0.2.5-alpha.23"

--- a/hack/deploy/chart/robot-operator/values.yaml
+++ b/hack/deploy/chart/robot-operator/values.yaml
@@ -23,7 +23,7 @@ controllerManager:
         - ALL
     image:
       repository: robolaunchio/robot-controller-manager
-      tag: v0.2.5-alpha.22
+      tag: v0.2.5-alpha.23
     resources:
       limits:
         cpu: 500m

--- a/hack/deploy/manifests/robot_operator.yaml
+++ b/hack/deploy/manifests/robot_operator.yaml
@@ -6937,7 +6937,7 @@ spec:
             - --leader-elect
           command:
             - /manager
-          image: robolaunchio/robot-controller-manager:v0.2.5-alpha.22
+          image: robolaunchio/robot-controller-manager:v0.2.5-alpha.23
           livenessProbe:
             httpGet:
               path: /healthz

--- a/pkg/controllers/robot/discovery_server/discoveryserver_controller.go
+++ b/pkg/controllers/robot/discovery_server/discoveryserver_controller.go
@@ -112,6 +112,13 @@ func (r *DiscoveryServerReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		return ctrl.Result{}, err
 	}
 
+	if instance.Spec.Type == robotv1alpha1.DiscoveryServerInstanceTypeClient {
+		return ctrl.Result{
+			Requeue:      true,
+			RequeueAfter: 5 * time.Second,
+		}, nil
+	}
+
 	return ctrl.Result{}, nil
 }
 


### PR DESCRIPTION
# :herb: PR: Check DiscoveryServer IP Every 5 Seconds

## Description

- Discovery server IP is instantly updated if the `.spec.type` fields is `Server`.
- Discovery server IP is updated 5 seconds (max) later if the `.spec.type` fields is `Client`.

Closes #145 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How can it be tested?

It can be tested by killing discovery server pod while watching owned config maps of DiscoveryServer objects.
