### PR TITLE
PR: Persist Websocket Connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 <a name="unreleased"></a>
 ## [Unreleased]
 
+### Fix
+- **ingress:** define keys and values for annotations
+
+
+<a name="v0.2.5-alpha.27"></a>
+## [v0.2.5-alpha.27] - 2023-07-12
 
 <a name="v0.2.5-alpha.26"></a>
 ## [v0.2.5-alpha.26] - 2023-07-11
@@ -185,7 +191,8 @@
 - Merge pull request [#24](https://github.com/robolaunch/robot-operator/issues/24) from robolaunch/23-allow-multiple-launches
 
 
-[Unreleased]: https://github.com/robolaunch/robot-operator/compare/v0.2.5-alpha.26...HEAD
+[Unreleased]: https://github.com/robolaunch/robot-operator/compare/v0.2.5-alpha.27...HEAD
+[v0.2.5-alpha.27]: https://github.com/robolaunch/robot-operator/compare/v0.2.5-alpha.26...v0.2.5-alpha.27
 [v0.2.5-alpha.26]: https://github.com/robolaunch/robot-operator/compare/v0.2.5-alpha.25...v0.2.5-alpha.26
 [v0.2.5-alpha.25]: https://github.com/robolaunch/robot-operator/compare/v0.2.5-alpha.24...v0.2.5-alpha.25
 [v0.2.5-alpha.24]: https://github.com/robolaunch/robot-operator/compare/v0.2.5-alpha.23...v0.2.5-alpha.24

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: robolaunchio/robot-controller-manager
-  newTag: v0.2.5-alpha.27
+  newTag: v0.2.5-alpha.28

--- a/hack/deploy/chart/robot-operator/Chart.yaml
+++ b/hack/deploy/chart/robot-operator/Chart.yaml
@@ -13,9 +13,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.5-alpha.27
+version: 0.2.5-alpha.28
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.2.5-alpha.27"
+appVersion: "v0.2.5-alpha.28"

--- a/hack/deploy/chart/robot-operator/values.yaml
+++ b/hack/deploy/chart/robot-operator/values.yaml
@@ -23,7 +23,7 @@ controllerManager:
         - ALL
     image:
       repository: robolaunchio/robot-controller-manager
-      tag: v0.2.5-alpha.27
+      tag: v0.2.5-alpha.28
     resources:
       limits:
         cpu: 500m

--- a/hack/deploy/manifests/robot_operator.yaml
+++ b/hack/deploy/manifests/robot_operator.yaml
@@ -6937,7 +6937,7 @@ spec:
             - --leader-elect
           command:
             - /manager
-          image: robolaunchio/robot-controller-manager:v0.2.5-alpha.27
+          image: robolaunchio/robot-controller-manager:v0.2.5-alpha.28
           livenessProbe:
             httpGet:
               path: /healthz

--- a/internal/resources/relay_server.go
+++ b/internal/resources/relay_server.go
@@ -112,6 +112,7 @@ func GetRelayServerIngress(relayserver *robotv1alpha1.RelayServer, ingressNamesp
 		internal.INGRESS_CERT_MANAGER_KEY:            internal.INGRESS_CERT_MANAGER_VAL,
 		internal.INGRESS_NGINX_PROXY_BUFFER_SIZE_KEY: internal.INGRESS_NGINX_PROXY_BUFFER_SIZE_VAL,
 		internal.INGRESS_NGINX_REWRITE_TARGET_KEY:    internal.INGRESS_NGINX_REWRITE_TARGET_VAL,
+		internal.INGRESS_PROXY_READ_TIMEOUT_KEY:      internal.INGRESS_PROXY_READ_TIMEOUT_VAL,
 	}
 
 	pathTypePrefix := networkingv1.PathTypePrefix

--- a/internal/resources/robot_ide.go
+++ b/internal/resources/robot_ide.go
@@ -157,6 +157,7 @@ func GetRobotIDEIngress(robotIDE *robotv1alpha1.RobotIDE, ingressNamespacedName 
 		internal.INGRESS_CERT_MANAGER_KEY:            internal.INGRESS_CERT_MANAGER_VAL,
 		internal.INGRESS_NGINX_PROXY_BUFFER_SIZE_KEY: internal.INGRESS_NGINX_PROXY_BUFFER_SIZE_VAL,
 		internal.INGRESS_NGINX_REWRITE_TARGET_KEY:    internal.INGRESS_NGINX_REWRITE_TARGET_VAL,
+		internal.INGRESS_PROXY_READ_TIMEOUT_KEY:      internal.INGRESS_PROXY_READ_TIMEOUT_VAL,
 	}
 
 	pathTypePrefix := networkingv1.PathTypePrefix

--- a/internal/resources/robot_vdi.go
+++ b/internal/resources/robot_vdi.go
@@ -247,6 +247,7 @@ func GetRobotVDIIngress(robotVDI *robotv1alpha1.RobotVDI, ingressNamespacedName 
 		internal.INGRESS_NGINX_PROXY_BUFFER_SIZE_KEY:    internal.INGRESS_NGINX_PROXY_BUFFER_SIZE_VAL,
 		internal.INGRESS_NGINX_PROXY_BUFFERS_NUMBER_KEY: internal.INGRESS_VDI_NGINX_PROXY_BUFFERS_NUMBER_VAL,
 		internal.INGRESS_NGINX_REWRITE_TARGET_KEY:       internal.INGRESS_NGINX_REWRITE_TARGET_VAL,
+		internal.INGRESS_PROXY_READ_TIMEOUT_KEY:         internal.INGRESS_PROXY_READ_TIMEOUT_VAL,
 	}
 
 	pathTypePrefix := networkingv1.PathTypePrefix

--- a/internal/resources/ros_bridge.go
+++ b/internal/resources/ros_bridge.go
@@ -108,6 +108,7 @@ func GetBridgeIngress(rosBridge *robotv1alpha1.ROSBridge, ingressNamespacedName 
 		internal.INGRESS_CERT_MANAGER_KEY:            internal.INGRESS_CERT_MANAGER_VAL,
 		internal.INGRESS_NGINX_PROXY_BUFFER_SIZE_KEY: internal.INGRESS_NGINX_PROXY_BUFFER_SIZE_VAL,
 		internal.INGRESS_NGINX_REWRITE_TARGET_KEY:    internal.INGRESS_NGINX_REWRITE_TARGET_VAL,
+		internal.INGRESS_PROXY_READ_TIMEOUT_KEY:      internal.INGRESS_PROXY_READ_TIMEOUT_VAL,
 	}
 
 	pathTypePrefix := networkingv1.PathTypePrefix

--- a/internal/shared.go
+++ b/internal/shared.go
@@ -147,8 +147,10 @@ const (
 	INGRESS_AUTH_RESPONSE_HEADERS_KEY     = "nginx.ingress.kubernetes.io/auth-response-headers"
 	INGRESS_AUTH_RESPONSE_HEADERS_VAL     = "x-auth-request-user, x-auth-request-email, x-auth-request-access-token"
 	INGRESS_CONFIGURATION_SNIPPET_KEY     = "nginx.ingress.kubernetes.io/configuration-snippet"
-	INGRESS_PROXY_READ_TIMEOUT            = "7200"
-	INGRESS_PROXY_SEND_TIMEOUT            = "7200"
+	INGRESS_PROXY_READ_TIMEOUT_KEY        = "nginx.ingress.kubernetes.io/proxy-read-timeout"
+	INGRESS_PROXY_READ_TIMEOUT_VAL        = "7200"
+	INGRESS_PROXY_SEND_TIMEOUT_KEY        = "nginx.ingress.kubernetes.io/proxy-send-timeout"
+	INGRESS_PROXY_SEND_TIMEOUT_VAL        = "7200"
 	INGRESS_VDI_CONFIGURATION_SNIPPET_VAL = "" +
 		"        #proxy_set_header Host $host;\n" +
 		"		proxy_set_header X-Real-IP $remote_addr;\n" +

--- a/internal/shared.go
+++ b/internal/shared.go
@@ -147,6 +147,8 @@ const (
 	INGRESS_AUTH_RESPONSE_HEADERS_KEY     = "nginx.ingress.kubernetes.io/auth-response-headers"
 	INGRESS_AUTH_RESPONSE_HEADERS_VAL     = "x-auth-request-user, x-auth-request-email, x-auth-request-access-token"
 	INGRESS_CONFIGURATION_SNIPPET_KEY     = "nginx.ingress.kubernetes.io/configuration-snippet"
+	INGRESS_PROXY_READ_TIMEOUT            = "7200"
+	INGRESS_PROXY_SEND_TIMEOUT            = "7200"
 	INGRESS_VDI_CONFIGURATION_SNIPPET_VAL = "" +
 		"        #proxy_set_header Host $host;\n" +
 		"		proxy_set_header X-Real-IP $remote_addr;\n" +


### PR DESCRIPTION
# :herb: PR: Persist Websocket Connections

## Description

Ingress resources created by operator are updated. Here's the annotation added:

```yaml
nginx.ingress.kubernetes.io/proxy-read-timeout: 7200
nginx.ingress.kubernetes.io/proxy-send-timeout: 7200
```

Closes #149

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How can it be tested?

Can be tested by inspecting VDI websocket connection started over ingress.
