### PR TITLE
PR: Use Defaulting Webhooks for Workspace Definiton

### DIFF
--- a/pkg/api/roboscale.io/v1alpha1/manager_webhook.go
+++ b/pkg/api/roboscale.io/v1alpha1/manager_webhook.go
@@ -35,6 +35,8 @@ import (
 // WorkspaceManager webhooks
 // ********************************
 
+var defaultWorkspacePath = "/home/robolaunch/workspaces"
+
 // log is for logging in this package.
 var workspacemanagerlog = logf.Log.WithName("workspacemanager-resource")
 
@@ -52,6 +54,7 @@ var _ webhook.Defaulter = &WorkspaceManager{}
 func (r *WorkspaceManager) Default() {
 	workspacemanagerlog.Info("default", "name", r.Name)
 	// _ = r.setRepositoryInfo()
+	r.setWorkspacesPath()
 }
 
 //+kubebuilder:webhook:path=/validate-robot-roboscale-io-v1alpha1-workspacemanager,mutating=false,failurePolicy=fail,sideEffects=None,groups=robot.roboscale.io,resources=workspacemanagers,verbs=create;update,versions=v1alpha1,name=vworkspacemanager.kb.io,admissionReviewVersions=v1
@@ -120,6 +123,12 @@ func (r *WorkspaceManager) setRepositoryInfo() error {
 
 	return nil
 
+}
+
+func (r *WorkspaceManager) setWorkspacesPath() {
+	if reflect.DeepEqual(r.Spec.WorkspacesPath, "") {
+		r.Spec.WorkspacesPath = defaultWorkspacePath
+	}
 }
 
 func getPathVariables(URL string) (string, string, error) {

--- a/pkg/api/roboscale.io/v1alpha1/robot_webhook.go
+++ b/pkg/api/roboscale.io/v1alpha1/robot_webhook.go
@@ -31,6 +31,7 @@ func (r *Robot) Default() {
 
 	DefaultRepositoryPaths(r)
 	_ = r.setRepositoryInfo()
+	r.setWorkspacesPath()
 }
 
 func DefaultRepositoryPaths(r *Robot) {
@@ -200,6 +201,18 @@ func (r *Robot) setRepositoryInfo() error {
 
 	return nil
 
+}
+
+func (r *Robot) setWorkspacesPath() {
+	if reflect.DeepEqual(r.Spec.WorkspaceManagerTemplate, WorkspaceManagerSpec{}) {
+		r.Spec.WorkspaceManagerTemplate = WorkspaceManagerSpec{
+			WorkspacesPath: defaultWorkspacePath,
+		}
+	}
+
+	if reflect.DeepEqual(r.Spec.WorkspaceManagerTemplate.WorkspacesPath, "") {
+		r.Spec.WorkspaceManagerTemplate.WorkspacesPath = defaultWorkspacePath
+	}
 }
 
 // ********************************


### PR DESCRIPTION
# :herb: PR: Use Defaulting Webhooks for Workspace Definiton

## Description

- WorkspaceManager's `.spec.workspacesPath` field is defaulted
- Robot's `.spec.workspaceManagerTemplate.workspacesPath` field is defaulted

Closes #153

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How can it be tested?

Can be tested by creating these resources with these fields empty.
