### PR TITLE
PR: Set Target VDI Automatically for LaunchManager

### DIFF
--- a/pkg/controllers/launch_manager/create.go
+++ b/pkg/controllers/launch_manager/create.go
@@ -17,9 +17,13 @@ func (r *LaunchManagerReconciler) createLaunchPod(ctx context.Context, instance 
 		return err
 	}
 
+	// Use RobotVDI display if
+	// - any of the launch objects needs display
+	// - target VDI label is not set empty (TODO: should be deprecated)
+	// - RobotVDI is created
 	robotVDI := &robotv1alpha1.RobotVDI{}
-	if resources.InstanceNeedDisplay(*instance, *robot) && label.GetTargetRobotVDI(instance) != "" {
-		robotVDI, err = r.reconcileGetTargetRobotVDI(ctx, instance)
+	if resources.InstanceNeedDisplay(*instance, *robot) && label.GetTargetRobotVDI(instance) != "" && robot.Status.RobotDevSuiteStatus.Status.RobotVDIStatus.Resource.Created {
+		robotVDI, err = r.reconcileGetTargetRobotVDI(ctx, instance, *robot)
 		if err != nil {
 			return err
 		}

--- a/pkg/controllers/launch_manager/helpers.go
+++ b/pkg/controllers/launch_manager/helpers.go
@@ -54,11 +54,11 @@ func (r *LaunchManagerReconciler) reconcileGetTargetRobot(ctx context.Context, i
 	return robot, nil
 }
 
-func (r *LaunchManagerReconciler) reconcileGetTargetRobotVDI(ctx context.Context, instance *robotv1alpha1.LaunchManager) (*robotv1alpha1.RobotVDI, error) {
+func (r *LaunchManagerReconciler) reconcileGetTargetRobotVDI(ctx context.Context, instance *robotv1alpha1.LaunchManager, robot robotv1alpha1.Robot) (*robotv1alpha1.RobotVDI, error) {
 	robotVDI := &robotv1alpha1.RobotVDI{}
 	err := r.Get(ctx, types.NamespacedName{
 		Namespace: instance.Namespace,
-		Name:      label.GetTargetRobotVDI(instance),
+		Name:      robot.Status.RobotDevSuiteStatus.Status.RobotVDIStatus.Resource.Reference.Name,
 	}, robotVDI)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
# :herb: PR: Set Target VDI Automatically for LaunchManager

## Description

- LaunchManager's label with key `robolaunch.io/target-vdi` is deprecated
- Target VDI is specified automatically if it's enabled

Closes #156