### PR TITLE
PR: Select ROS Domain ID for Robots

### DIFF
--- a/internal/configure/domain_id.go
+++ b/internal/configure/domain_id.go
@@ -1,0 +1,30 @@
+package configure
+
+import (
+	"strconv"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+func InjectPodROSDomainID(pod *corev1.Pod, domainID int) *corev1.Pod {
+
+	placeROSDomainIDEnvironmentVariables(pod, domainID)
+
+	return pod
+}
+
+func placeROSDomainIDEnvironmentVariables(pod *corev1.Pod, domainID int) {
+
+	environmentVariables := []corev1.EnvVar{
+		{
+			Name:  "ROS_DOMAIN_ID",
+			Value: strconv.Itoa(domainID),
+		},
+	}
+
+	for k, container := range pod.Spec.Containers {
+		container.Env = append(container.Env, environmentVariables...)
+		pod.Spec.Containers[k] = container
+	}
+
+}

--- a/internal/configure/domain_id.go
+++ b/internal/configure/domain_id.go
@@ -6,7 +6,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-func InjectPodROSDomainID(pod *corev1.Pod, domainID int) *corev1.Pod {
+func InjectROSDomainID(pod *corev1.Pod, domainID int) *corev1.Pod {
 
 	placeROSDomainIDEnvironmentVariables(pod, domainID)
 

--- a/internal/resources/discovery_server.go
+++ b/internal/resources/discovery_server.go
@@ -55,6 +55,7 @@ func GetDiscoveryServerPod(discoveryServer *robotv1alpha1.DiscoveryServer, podNa
 	}
 
 	configure.SchedulePod(&discoveryServerPod, label.GetTenancyMap(discoveryServer))
+	configure.InjectROSDomainID(&discoveryServerPod, discoveryServer.Spec.DomainID)
 
 	return &discoveryServerPod
 }

--- a/internal/resources/launch_manager.go
+++ b/internal/resources/launch_manager.go
@@ -47,8 +47,9 @@ func GetLaunchPod(launchManager *robotv1alpha1.LaunchManager, podNamespacedName 
 	}
 
 	configure.SchedulePod(&launchPod, label.GetTenancyMap(launchManager))
-	configure.InjectGenericEnvironmentVariables(&launchPod, robot)                                                     // Environment variables
-	configure.InjectRMWImplementationConfiguration(&launchPod, robot)                                                  // RMW implementation configuration
+	configure.InjectGenericEnvironmentVariables(&launchPod, robot)    // Environment variables
+	configure.InjectRMWImplementationConfiguration(&launchPod, robot) // RMW implementation configuration
+	configure.InjectROSDomainID(&launchPod, robot.Spec.DomainID)
 	configure.InjectPodDiscoveryServerConnection(&launchPod, robot.Status.DiscoveryServerStatus.Status.ConnectionInfo) // Discovery server configuration
 	configure.InjectRuntimeClass(&launchPod, robot, node)
 

--- a/internal/resources/robot_ide.go
+++ b/internal/resources/robot_ide.go
@@ -94,6 +94,7 @@ func GetRobotIDEPod(robotIDE *robotv1alpha1.RobotIDE, podNamespacedName *types.N
 	configure.InjectGenericEnvironmentVariables(&pod, robot)
 	configure.InjectLinuxUserAndGroup(&pod, robot)
 	configure.InjectRMWImplementationConfiguration(&pod, robot)
+	configure.InjectROSDomainID(&pod, robot.Spec.DomainID)
 	configure.InjectPodDiscoveryServerConnection(&pod, robot.Status.DiscoveryServerStatus.Status.ConnectionInfo)
 	configure.InjectRuntimeClass(&pod, robot, node)
 	if robotIDE.Spec.Display && label.GetTargetRobotVDI(robotIDE) != "" {

--- a/internal/resources/robot_vdi.go
+++ b/internal/resources/robot_vdi.go
@@ -153,6 +153,7 @@ func GetRobotVDIPod(robotVDI *robotv1alpha1.RobotVDI, podNamespacedName *types.N
 	configure.SchedulePod(vdiPod, label.GetTenancyMap(robotVDI))
 	configure.InjectGenericEnvironmentVariables(vdiPod, robot)
 	configure.InjectRMWImplementationConfiguration(vdiPod, robot)
+	configure.InjectROSDomainID(vdiPod, robot.Spec.DomainID)
 	configure.InjectPodDiscoveryServerConnection(vdiPod, robot.Status.DiscoveryServerStatus.Status.ConnectionInfo)
 	configure.InjectPodDisplayConfiguration(vdiPod, *robotVDI)
 	configure.InjectRuntimeClass(vdiPod, robot, node)

--- a/internal/resources/ros_bridge.go
+++ b/internal/resources/ros_bridge.go
@@ -55,6 +55,7 @@ func GetBridgePod(rosbridge *robotv1alpha1.ROSBridge, podNamespacedName *types.N
 	configure.SchedulePod(&bridgePod, label.GetTenancyMap(rosbridge))
 	configure.InjectPodDiscoveryServerConnection(&bridgePod, robot.Status.DiscoveryServerStatus.Status.ConnectionInfo)
 	configure.InjectRMWImplementationConfiguration(&bridgePod, robot)
+	configure.InjectROSDomainID(&bridgePod, robot.Spec.DomainID)
 
 	return &bridgePod
 }

--- a/pkg/api/roboscale.io/v1alpha1/robot_types.go
+++ b/pkg/api/roboscale.io/v1alpha1/robot_types.go
@@ -213,6 +213,9 @@ type RobotSpec struct {
 	// +kubebuilder:validation:Required
 	// +kubebuilder:default=rmw_fastrtps_cpp
 	RMWImplementation RMWImplementation `json:"rmwImplementation"`
+	// ROS domain ID for robot. See https://docs.ros.org/en/foxy/Concepts/About-Domain-ID.html.
+	// +kubebuilder:default=0
+	DomainID int `json:"domainID"`
 	// Total storage amount to persist via Robot. Unit of measurement is MB. (eg. `10240` corresponds 10 GB)
 	// This amount is being shared between different components.
 	Storage Storage `json:"storage,omitempty"`

--- a/pkg/api/roboscale.io/v1alpha1/robot_types.go
+++ b/pkg/api/roboscale.io/v1alpha1/robot_types.go
@@ -214,6 +214,8 @@ type RobotSpec struct {
 	// +kubebuilder:default=rmw_fastrtps_cpp
 	RMWImplementation RMWImplementation `json:"rmwImplementation"`
 	// ROS domain ID for robot. See https://docs.ros.org/en/foxy/Concepts/About-Domain-ID.html.
+	// +kubebuilder:validation:Minimum=0
+	// +kubebuilder:validation:Maximum=101
 	// +kubebuilder:default=0
 	DomainID int `json:"domainID"`
 	// Total storage amount to persist via Robot. Unit of measurement is MB. (eg. `10240` corresponds 10 GB)
@@ -335,6 +337,8 @@ const (
 // DiscoveryServerSpec defines the desired state of DiscoveryServer.
 type DiscoveryServerSpec struct {
 	// ROS domain ID for robot. See https://docs.ros.org/en/foxy/Concepts/About-Domain-ID.html.
+	// +kubebuilder:validation:Minimum=0
+	// +kubebuilder:validation:Maximum=101
 	// +kubebuilder:default=0
 	DomainID int `json:"domainID"`
 	// Instance type can be either `Server` or `Client`.

--- a/pkg/api/roboscale.io/v1alpha1/robot_types.go
+++ b/pkg/api/roboscale.io/v1alpha1/robot_types.go
@@ -334,6 +334,9 @@ const (
 
 // DiscoveryServerSpec defines the desired state of DiscoveryServer.
 type DiscoveryServerSpec struct {
+	// ROS domain ID for robot. See https://docs.ros.org/en/foxy/Concepts/About-Domain-ID.html.
+	// +kubebuilder:default=0
+	DomainID int `json:"domainID"`
 	// Instance type can be either `Server` or `Client`.
 	// If `Server`, instance creates discovery server resources and workloads.
 	// Other `Client` instances can connect to the `Server` instance.

--- a/pkg/api/roboscale.io/v1alpha1/robot_webhook.go
+++ b/pkg/api/roboscale.io/v1alpha1/robot_webhook.go
@@ -215,6 +215,10 @@ func (r *Robot) setWorkspacesPath() {
 	}
 }
 
+func (r *Robot) setDiscoveryServerDomainID() {
+	r.Spec.DiscoveryServerTemplate.DomainID = r.Spec.DomainID
+}
+
 // ********************************
 // DiscoveryServer webhooks
 // ********************************

--- a/pkg/api/roboscale.io/v1alpha1/robot_webhook.go
+++ b/pkg/api/roboscale.io/v1alpha1/robot_webhook.go
@@ -32,6 +32,7 @@ func (r *Robot) Default() {
 	DefaultRepositoryPaths(r)
 	_ = r.setRepositoryInfo()
 	r.setWorkspacesPath()
+	r.setDiscoveryServerDomainID()
 }
 
 func DefaultRepositoryPaths(r *Robot) {


### PR DESCRIPTION
# :herb: PR: Select ROS Domain ID for Robots

## Description

- Robot's domain ID can be set using the field `.spec.domainID`
- DiscoveryServer's domain ID can be set using the field `.spec.domainID`
- Domain ID is set to 0 by default.

Closes #65

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How can it be tested?

Can be tested by setting `.spec.domainID` field with value other than 0.
