### PR TITLE
PR: Set `WORKSPACE` Environment Variable for Workspace-Scoped Objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 ## [Unreleased]
 
 
+<a name="v0.2.5-alpha.31"></a>
+## [v0.2.5-alpha.31] - 2023-08-07
+
 <a name="v0.2.5-alpha.30"></a>
 ## [v0.2.5-alpha.30] - 2023-08-02
 ### Feat
@@ -214,7 +217,8 @@
 - Merge pull request [#24](https://github.com/robolaunch/robot-operator/issues/24) from robolaunch/23-allow-multiple-launches
 
 
-[Unreleased]: https://github.com/robolaunch/robot-operator/compare/v0.2.5-alpha.30...HEAD
+[Unreleased]: https://github.com/robolaunch/robot-operator/compare/v0.2.5-alpha.31...HEAD
+[v0.2.5-alpha.31]: https://github.com/robolaunch/robot-operator/compare/v0.2.5-alpha.30...v0.2.5-alpha.31
 [v0.2.5-alpha.30]: https://github.com/robolaunch/robot-operator/compare/v0.2.5-alpha.29...v0.2.5-alpha.30
 [v0.2.5-alpha.29]: https://github.com/robolaunch/robot-operator/compare/v0.2.5-alpha.28...v0.2.5-alpha.29
 [v0.2.5-alpha.28]: https://github.com/robolaunch/robot-operator/compare/v0.2.5-alpha.27...v0.2.5-alpha.28

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: robolaunchio/robot-controller-manager
-  newTag: v0.2.5-alpha.31
+  newTag: v0.2.5-alpha.32

--- a/hack/deploy/chart/robot-operator/Chart.yaml
+++ b/hack/deploy/chart/robot-operator/Chart.yaml
@@ -13,9 +13,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.5-alpha.31
+version: 0.2.5-alpha.32
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.2.5-alpha.31"
+appVersion: "v0.2.5-alpha.32"

--- a/hack/deploy/chart/robot-operator/values.yaml
+++ b/hack/deploy/chart/robot-operator/values.yaml
@@ -32,7 +32,7 @@ controllerManager:
         - ALL
     image:
       repository: robolaunchio/robot-controller-manager
-      tag: v0.2.5-alpha.31
+      tag: v0.2.5-alpha.32
     resources:
       limits:
         cpu: 500m

--- a/hack/deploy/manifests/robot_operator.yaml
+++ b/hack/deploy/manifests/robot_operator.yaml
@@ -6948,7 +6948,7 @@ spec:
             - --leader-elect
           command:
             - /manager
-          image: robolaunchio/robot-controller-manager:v0.2.5-alpha.31
+          image: robolaunchio/robot-controller-manager:v0.2.5-alpha.32
           livenessProbe:
             httpGet:
               path: /healthz

--- a/internal/configure/environment.go
+++ b/internal/configure/environment.go
@@ -10,6 +10,7 @@ func InjectGenericEnvironmentVariablesForPodSpec(podSpec *corev1.PodSpec, robot 
 
 	for key, cont := range podSpec.Containers {
 		cont.Env = append(cont.Env, internal.Env("WORKSPACES_PATH", robot.Spec.WorkspaceManagerTemplate.WorkspacesPath))
+		cont.Env = append(cont.Env, internal.Env("ROS2_SETUP_PATH", "/opt/ros/"+string(robot.Spec.Distributions[0])+"/setup.bash"))
 		podSpec.Containers[key] = cont
 	}
 
@@ -20,6 +21,7 @@ func InjectGenericEnvironmentVariables(pod *corev1.Pod, robot robotv1alpha1.Robo
 
 	for key, cont := range pod.Spec.Containers {
 		cont.Env = append(cont.Env, internal.Env("WORKSPACES_PATH", robot.Spec.WorkspaceManagerTemplate.WorkspacesPath))
+		cont.Env = append(cont.Env, internal.Env("ROS2_SETUP_PATH", "/opt/ros/"+string(robot.Spec.Distributions[0])+"/setup.bash"))
 		pod.Spec.Containers[key] = cont
 	}
 

--- a/internal/configure/environment.go
+++ b/internal/configure/environment.go
@@ -25,3 +25,23 @@ func InjectGenericEnvironmentVariables(pod *corev1.Pod, robot robotv1alpha1.Robo
 
 	return pod
 }
+
+func InjectWorkspaceEnvironmentVariableForPodSpec(podSpec *corev1.PodSpec, robot robotv1alpha1.Robot, workspace string) *corev1.PodSpec {
+
+	for key, cont := range podSpec.Containers {
+		cont.Env = append(cont.Env, internal.Env("WORKSPACE", robot.Spec.WorkspaceManagerTemplate.WorkspacesPath+"/"+workspace))
+		podSpec.Containers[key] = cont
+	}
+
+	return podSpec
+}
+
+func InjectWorkspaceEnvironmentVariable(pod *corev1.Pod, robot robotv1alpha1.Robot, workspace string) *corev1.Pod {
+
+	for key, cont := range pod.Spec.Containers {
+		cont.Env = append(cont.Env, internal.Env("WORKSPACE", robot.Spec.WorkspaceManagerTemplate.WorkspacesPath+"/"+workspace))
+		pod.Spec.Containers[key] = cont
+	}
+
+	return pod
+}

--- a/internal/configure/environment.go
+++ b/internal/configure/environment.go
@@ -26,6 +26,11 @@ func InjectGenericEnvironmentVariables(pod *corev1.Pod, robot robotv1alpha1.Robo
 	return pod
 }
 
+func InjectWorkspaceEnvironmentVariableForContainer(container *corev1.Container, robot robotv1alpha1.Robot, workspace string) *corev1.Container {
+	container.Env = append(container.Env, internal.Env("WORKSPACE", robot.Spec.WorkspaceManagerTemplate.WorkspacesPath+"/"+workspace))
+	return container
+}
+
 func InjectWorkspaceEnvironmentVariableForPodSpec(podSpec *corev1.PodSpec, robot robotv1alpha1.Robot, workspace string) *corev1.PodSpec {
 
 	for key, cont := range podSpec.Containers {

--- a/internal/resources/build_manager.go
+++ b/internal/resources/build_manager.go
@@ -90,6 +90,7 @@ func GetBuildJob(buildManager *robotv1alpha1.BuildManager, robot *robotv1alpha1.
 
 	configure.InjectGenericEnvironmentVariablesForPodSpec(&podSpec, *robot)
 	configure.InjectLinuxUserAndGroupForPodSpec(&podSpec, *robot)
+	configure.InjectWorkspaceEnvironmentVariableForPodSpec(&podSpec, *robot, step.Workspace)
 	configure.InjectRMWImplementationConfigurationForPodSpec(&podSpec, *robot)
 
 	job := batchv1.Job{

--- a/internal/resources/launch_manager.go
+++ b/internal/resources/launch_manager.go
@@ -98,6 +98,8 @@ func getContainer(launch robotv1alpha1.Launch, launchName string, robot robotv1a
 		},
 	}
 
+	configure.InjectWorkspaceEnvironmentVariableForContainer(&container, robot, launch.Workspace)
+
 	return container
 }
 


### PR DESCRIPTION
# :herb: PR: Set `WORKSPACE` Environment Variable for Workspace-Scoped Objects

## Description

- BuildManager containers use `WORKSPACE` environment variable
- LaunchManager containers use `WORKSPACE` environment variable

Closes #159

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How can it be tested?

Can be tested by running `echo $WORKSPACE` inside BM or LM containers.
