### PR TITLE
PR: Support Custom Image Registry

### DIFF
--- a/internal/node/image.go
+++ b/internal/node/image.go
@@ -56,10 +56,10 @@ type ReadyRobotProperties struct {
 func GetReadyRobotProperties(robot robotv1alpha1.Robot) ReadyRobotProperties {
 	labels := robot.GetLabels()
 
-	if registry, hasRegistry := labels[internal.ROBOT_IMAGE_REGISTRY]; hasRegistry {
-		if user, hasUser := labels[internal.ROBOT_IMAGE_USER]; hasUser {
-			if repository, hasRepository := labels[internal.ROBOT_IMAGE_REPOSITORY]; hasRepository {
-				if tag, hasTag := labels[internal.ROBOT_IMAGE_TAG]; hasTag {
+	if registry, hasRegistry := labels[internal.ROBOT_IMAGE_REGISTRY_LABEL_KEY]; hasRegistry {
+		if user, hasUser := labels[internal.ROBOT_IMAGE_USER_LABEL_KEY]; hasUser {
+			if repository, hasRepository := labels[internal.ROBOT_IMAGE_REPOSITORY_LABEL_KEY]; hasRepository {
+				if tag, hasTag := labels[internal.ROBOT_IMAGE_TAG_LABEL_KEY]; hasTag {
 					return ReadyRobotProperties{
 						Enabled: true,
 						Image:   registry + "/" + user + "/" + repository + ":" + tag,
@@ -101,13 +101,18 @@ func GetImageForRobot(node corev1.Node, robot robotv1alpha1.Robot) (string, erro
 			return "", err
 		}
 
+		registry, hasRegistry := robot.Labels[internal.ROBOT_IMAGE_REGISTRY_LABEL_KEY]
+		if !hasRegistry {
+			return "", errors.New("registry is not found in label with key " + internal.ROBOT_IMAGE_REGISTRY_LABEL_KEY)
+		}
+
 		organization := "robolaunchio"
 		repository := "devspace-robotics"
 		tagBuilder.WriteString(imageProps.Application.Name + "-")
 		tagBuilder.WriteString(imageProps.Application.Version)
 		tagBuilder.WriteString("-" + imageProps.DevSpaceImage.UbuntuDistro + "-" + imageProps.DevSpaceImage.Desktop)
 		tagBuilder.WriteString("-" + imageProps.DevSpaceImage.Version)
-		imageBuilder.WriteString(filepath.Join(organization, repository) + ":")
+		imageBuilder.WriteString(filepath.Join(registry, organization, repository) + ":")
 		imageBuilder.WriteString(tagBuilder.String())
 
 	}
@@ -131,6 +136,11 @@ func GetImageForEnvironment(node corev1.Node, robot robotv1alpha1.Robot) (string
 		imageProps, err := getImagePropsForEnvironment(platformVersion)
 		if err != nil {
 			return "", err
+		}
+
+		registry, hasRegistry := robot.Labels[internal.ROBOT_IMAGE_REGISTRY_LABEL_KEY]
+		if !hasRegistry {
+			return "", errors.New("registry is not found in label with key " + internal.ROBOT_IMAGE_REGISTRY_LABEL_KEY)
 		}
 
 		organization := imageProps.Organization
@@ -201,7 +211,7 @@ func GetImageForEnvironment(node corev1.Node, robot robotv1alpha1.Robot) (string
 		tagBuilder.WriteString(chosenElement.DevSpaceImage.Desktop + "-")
 		tagBuilder.WriteString(chosenElement.DevSpaceImage.Version)
 
-		imageBuilder.WriteString(filepath.Join(organization, repository) + ":")
+		imageBuilder.WriteString(filepath.Join(registry, organization, repository) + ":")
 		imageBuilder.WriteString(tagBuilder.String())
 
 	}

--- a/internal/node/image.go
+++ b/internal/node/image.go
@@ -56,12 +56,14 @@ type ReadyRobotProperties struct {
 func GetReadyRobotProperties(robot robotv1alpha1.Robot) ReadyRobotProperties {
 	labels := robot.GetLabels()
 
-	if user, hasUser := labels[internal.ROBOT_IMAGE_USER]; hasUser {
-		if repository, hasRepository := labels[internal.ROBOT_IMAGE_REPOSITORY]; hasRepository {
-			if tag, hasTag := labels[internal.ROBOT_IMAGE_TAG]; hasTag {
-				return ReadyRobotProperties{
-					Enabled: true,
-					Image:   user + "/" + repository + ":" + tag,
+	if registry, hasRegistry := labels[internal.ROBOT_IMAGE_REGISTRY]; hasRegistry {
+		if user, hasUser := labels[internal.ROBOT_IMAGE_USER]; hasUser {
+			if repository, hasRepository := labels[internal.ROBOT_IMAGE_REPOSITORY]; hasRepository {
+				if tag, hasTag := labels[internal.ROBOT_IMAGE_TAG]; hasTag {
+					return ReadyRobotProperties{
+						Enabled: true,
+						Image:   registry + "/" + user + "/" + repository + ":" + tag,
+					}
 				}
 			}
 		}

--- a/internal/shared.go
+++ b/internal/shared.go
@@ -19,6 +19,7 @@ const (
 
 // Ready robot label
 const (
+	ROBOT_IMAGE_REGISTRY   = "docker.io"
 	ROBOT_IMAGE_USER       = "robolaunch.io/robot-image-user"
 	ROBOT_IMAGE_REPOSITORY = "robolaunch.io/robot-image-repository"
 	ROBOT_IMAGE_TAG        = "robolaunch.io/robot-image-tag"

--- a/internal/shared.go
+++ b/internal/shared.go
@@ -19,10 +19,10 @@ const (
 
 // Ready robot label
 const (
-	ROBOT_IMAGE_REGISTRY   = "docker.io"
-	ROBOT_IMAGE_USER       = "robolaunch.io/robot-image-user"
-	ROBOT_IMAGE_REPOSITORY = "robolaunch.io/robot-image-repository"
-	ROBOT_IMAGE_TAG        = "robolaunch.io/robot-image-tag"
+	ROBOT_IMAGE_REGISTRY_LABEL_KEY   = "robolaunch.io/robot-image-registry"
+	ROBOT_IMAGE_USER_LABEL_KEY       = "robolaunch.io/robot-image-user"
+	ROBOT_IMAGE_REPOSITORY_LABEL_KEY = "robolaunch.io/robot-image-repository"
+	ROBOT_IMAGE_TAG_LABEL_KEY        = "robolaunch.io/robot-image-tag"
 )
 
 // Target resource labels

--- a/pkg/api/roboscale.io/v1alpha1/robot_webhook.go
+++ b/pkg/api/roboscale.io/v1alpha1/robot_webhook.go
@@ -207,9 +207,9 @@ func (r *Robot) checkRobotDevSuite() error {
 }
 
 func (r *Robot) setDefaultLabels() {
-	r.SetLabels(map[string]string{
-		internal.ROBOT_IMAGE_REGISTRY: "docker.io",
-	})
+	if _, ok := r.Labels[internal.ROBOT_IMAGE_REGISTRY]; !ok {
+		r.Labels[internal.ROBOT_IMAGE_REGISTRY] = "docker.io"
+	}
 }
 
 func (r *Robot) setRepositoryPaths() {

--- a/pkg/api/roboscale.io/v1alpha1/robot_webhook.go
+++ b/pkg/api/roboscale.io/v1alpha1/robot_webhook.go
@@ -33,6 +33,7 @@ var _ webhook.Defaulter = &Robot{}
 func (r *Robot) Default() {
 	robotlog.Info("default", "name", r.Name)
 
+	r.setDefaultLabels()
 	r.setRepositoryPaths()
 	_ = r.setRepositoryInfo()
 	r.setWorkspacesPath()
@@ -203,6 +204,12 @@ func (r *Robot) checkRobotDevSuite() error {
 	}
 
 	return nil
+}
+
+func (r *Robot) setDefaultLabels() {
+	r.SetLabels(map[string]string{
+		internal.ROBOT_IMAGE_REGISTRY: "docker.io",
+	})
 }
 
 func (r *Robot) setRepositoryPaths() {

--- a/pkg/api/roboscale.io/v1alpha1/robot_webhook.go
+++ b/pkg/api/roboscale.io/v1alpha1/robot_webhook.go
@@ -33,22 +33,10 @@ var _ webhook.Defaulter = &Robot{}
 func (r *Robot) Default() {
 	robotlog.Info("default", "name", r.Name)
 
-	DefaultRepositoryPaths(r)
+	r.setRepositoryPaths()
 	_ = r.setRepositoryInfo()
 	r.setWorkspacesPath()
 	r.setDiscoveryServerDomainID()
-}
-
-func DefaultRepositoryPaths(r *Robot) {
-	for wsKey := range r.Spec.WorkspaceManagerTemplate.Workspaces {
-		ws := r.Spec.WorkspaceManagerTemplate.Workspaces[wsKey]
-		for repoKey := range ws.Repositories {
-			repo := ws.Repositories[repoKey]
-			repo.Path = r.Spec.WorkspaceManagerTemplate.WorkspacesPath + "/" + ws.Name + "/src/" + repoKey
-			ws.Repositories[repoKey] = repo
-		}
-		r.Spec.WorkspaceManagerTemplate.Workspaces[wsKey] = ws
-	}
 }
 
 //+kubebuilder:webhook:path=/validate-robot-roboscale-io-v1alpha1-robot,mutating=false,failurePolicy=fail,sideEffects=None,groups=robot.roboscale.io,resources=robots,verbs=create;update,versions=v1alpha1,name=vrobot.kb.io,admissionReviewVersions=v1
@@ -215,6 +203,18 @@ func (r *Robot) checkRobotDevSuite() error {
 	}
 
 	return nil
+}
+
+func (r *Robot) setRepositoryPaths() {
+	for wsKey := range r.Spec.WorkspaceManagerTemplate.Workspaces {
+		ws := r.Spec.WorkspaceManagerTemplate.Workspaces[wsKey]
+		for repoKey := range ws.Repositories {
+			repo := ws.Repositories[repoKey]
+			repo.Path = r.Spec.WorkspaceManagerTemplate.WorkspacesPath + "/" + ws.Name + "/src/" + repoKey
+			ws.Repositories[repoKey] = repo
+		}
+		r.Spec.WorkspaceManagerTemplate.Workspaces[wsKey] = ws
+	}
 }
 
 func (r *Robot) setRepositoryInfo() error {

--- a/pkg/api/roboscale.io/v1alpha1/robot_webhook.go
+++ b/pkg/api/roboscale.io/v1alpha1/robot_webhook.go
@@ -207,8 +207,8 @@ func (r *Robot) checkRobotDevSuite() error {
 }
 
 func (r *Robot) setDefaultLabels() {
-	if _, ok := r.Labels[internal.ROBOT_IMAGE_REGISTRY]; !ok {
-		r.Labels[internal.ROBOT_IMAGE_REGISTRY] = "docker.io"
+	if _, ok := r.Labels[internal.ROBOT_IMAGE_REGISTRY_LABEL_KEY]; !ok {
+		r.Labels[internal.ROBOT_IMAGE_REGISTRY_LABEL_KEY] = "docker.io"
 	}
 }
 


### PR DESCRIPTION
# :herb: PR: Support Custom Image Registry

## Description

- Label `robolaunch.io/robot-image-registry` is in use.
- Defaulted to `docker.io`.
- Cannot contain the character "/" (since it's value of label).

Closes #168

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How can it be tested?

Can be tested by manipulating the label mentioned above.
