### PR TITLE
PR: Support Querying `platform.yaml` from ConfigMap

### DIFF
--- a/internal/node/image.go
+++ b/internal/node/image.go
@@ -77,7 +77,7 @@ func GetImage(ctx context.Context, r client.Client, node corev1.Node, robot robo
 	if robot.Spec.Type == robotv1alpha1.TypeRobot {
 		return GetImageForRobot(ctx, r, node, robot)
 	} else if robot.Spec.Type == robotv1alpha1.TypeEnvironment {
-		return GetImageForEnvironment(node, robot)
+		return GetImageForEnvironment(ctx, r, node, robot)
 	}
 	return "", errors.New("cannot specify the resource type")
 }
@@ -119,7 +119,7 @@ func GetImageForRobot(ctx context.Context, r client.Client, node corev1.Node, ro
 	return imageBuilder.String(), nil
 }
 
-func GetImageForEnvironment(node corev1.Node, robot robotv1alpha1.Robot) (string, error) {
+func GetImageForEnvironment(ctx context.Context, r client.Client, node corev1.Node, robot robotv1alpha1.Robot) (string, error) {
 	var imageBuilder strings.Builder
 	var tagBuilder strings.Builder
 
@@ -132,7 +132,7 @@ func GetImageForEnvironment(node corev1.Node, robot robotv1alpha1.Robot) (string
 	} else {
 
 		platformVersion := GetPlatformVersion(node)
-		imageProps, err := getImagePropsForEnvironment(platformVersion)
+		imageProps, err := getImagePropsForEnvironment(ctx, r, platformVersion)
 		if err != nil {
 			return "", err
 		}

--- a/internal/node/image.go
+++ b/internal/node/image.go
@@ -2,8 +2,6 @@ package node
 
 import (
 	"errors"
-	"io"
-	"net/http"
 	"path/filepath"
 	"reflect"
 	"strings"
@@ -11,7 +9,6 @@ import (
 	cosmodrome "github.com/robolaunch/cosmodrome/pkg/api"
 	"github.com/robolaunch/robot-operator/internal"
 	robotv1alpha1 "github.com/robolaunch/robot-operator/pkg/api/roboscale.io/v1alpha1"
-	"gopkg.in/yaml.v2"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -234,81 +231,4 @@ func setPrecisionBetweenDistributions(distributions []robotv1alpha1.ROSDistro) s
 		return string(robotv1alpha1.ROSDistroFoxy) + "-" + string(robotv1alpha1.ROSDistroGalactic)
 	}
 	return ""
-}
-
-func getImagePropsForRobot(platformVersion, distro string) (Element, error) {
-
-	resp, err := http.Get(internal.IMAGE_MAP_URL)
-	if err != nil {
-		return Element{}, err
-	}
-
-	defer resp.Body.Close()
-
-	var yamlFile []byte
-	if resp.StatusCode == http.StatusOK {
-		yamlFile, err = io.ReadAll(resp.Body)
-		if err != nil {
-			return Element{}, err
-		}
-	}
-
-	var platform Platform
-	err = yaml.Unmarshal(yamlFile, &platform)
-	if err != nil {
-		return Element{}, err
-	}
-
-	distroFound := false
-	var imageProps Element
-	for _, v := range platform.Versions {
-		if v.Version == platformVersion {
-			for _, element := range v.Images.Domains["robotics"] {
-				if element.Application.Version == distro {
-					imageProps = element
-					distroFound = true
-					break
-				}
-			}
-		}
-	}
-
-	if !distroFound {
-		return Element{}, errors.New("distro not found in platform versioning map")
-	}
-
-	return imageProps, nil
-}
-
-func getImagePropsForEnvironment(platformVersion string) (Images, error) {
-
-	resp, err := http.Get(internal.IMAGE_MAP_URL)
-	if err != nil {
-		return Images{}, err
-	}
-
-	defer resp.Body.Close()
-
-	var yamlFile []byte
-	if resp.StatusCode == http.StatusOK {
-		yamlFile, err = io.ReadAll(resp.Body)
-		if err != nil {
-			return Images{}, err
-		}
-	}
-
-	var platform Platform
-	err = yaml.Unmarshal(yamlFile, &platform)
-	if err != nil {
-		return Images{}, err
-	}
-
-	var imageProps Images
-	for _, v := range platform.Versions {
-		if v.Version == platformVersion {
-			imageProps = v.Images
-		}
-	}
-
-	return imageProps, nil
 }

--- a/internal/node/platform.go
+++ b/internal/node/platform.go
@@ -13,7 +13,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func getPlatform(ctx context.Context, r client.Client, platformVersion, distro string) (Platform, error) {
+func getPlatform(ctx context.Context, r client.Client, platformVersion string) (Platform, error) {
 
 	// try config map
 	platformCmNamespacedName := types.NamespacedName{
@@ -62,7 +62,7 @@ func getPlatform(ctx context.Context, r client.Client, platformVersion, distro s
 
 func getImagePropsForRobot(ctx context.Context, r client.Client, platformVersion, distro string) (Element, error) {
 
-	platform, err := getPlatform(ctx, r, platformVersion, distro)
+	platform, err := getPlatform(ctx, r, platformVersion)
 	if err != nil {
 		return Element{}, err
 	}
@@ -88,25 +88,9 @@ func getImagePropsForRobot(ctx context.Context, r client.Client, platformVersion
 	return imageProps, nil
 }
 
-func getImagePropsForEnvironment(platformVersion string) (Images, error) {
+func getImagePropsForEnvironment(ctx context.Context, r client.Client, platformVersion string) (Images, error) {
 
-	resp, err := http.Get(internal.IMAGE_MAP_URL)
-	if err != nil {
-		return Images{}, err
-	}
-
-	defer resp.Body.Close()
-
-	var yamlFile []byte
-	if resp.StatusCode == http.StatusOK {
-		yamlFile, err = io.ReadAll(resp.Body)
-		if err != nil {
-			return Images{}, err
-		}
-	}
-
-	var platform Platform
-	err = yaml.Unmarshal(yamlFile, &platform)
+	platform, err := getPlatform(ctx, r, platformVersion)
 	if err != nil {
 		return Images{}, err
 	}

--- a/internal/node/platform.go
+++ b/internal/node/platform.go
@@ -1,0 +1,87 @@
+package node
+
+import (
+	"errors"
+	"io"
+	"net/http"
+
+	"github.com/robolaunch/robot-operator/internal"
+	"gopkg.in/yaml.v2"
+)
+
+func getImagePropsForRobot(platformVersion, distro string) (Element, error) {
+
+	resp, err := http.Get(internal.IMAGE_MAP_URL)
+	if err != nil {
+		return Element{}, err
+	}
+
+	defer resp.Body.Close()
+
+	var yamlFile []byte
+	if resp.StatusCode == http.StatusOK {
+		yamlFile, err = io.ReadAll(resp.Body)
+		if err != nil {
+			return Element{}, err
+		}
+	}
+
+	var platform Platform
+	err = yaml.Unmarshal(yamlFile, &platform)
+	if err != nil {
+		return Element{}, err
+	}
+
+	distroFound := false
+	var imageProps Element
+	for _, v := range platform.Versions {
+		if v.Version == platformVersion {
+			for _, element := range v.Images.Domains["robotics"] {
+				if element.Application.Version == distro {
+					imageProps = element
+					distroFound = true
+					break
+				}
+			}
+		}
+	}
+
+	if !distroFound {
+		return Element{}, errors.New("distro not found in platform versioning map")
+	}
+
+	return imageProps, nil
+}
+
+func getImagePropsForEnvironment(platformVersion string) (Images, error) {
+
+	resp, err := http.Get(internal.IMAGE_MAP_URL)
+	if err != nil {
+		return Images{}, err
+	}
+
+	defer resp.Body.Close()
+
+	var yamlFile []byte
+	if resp.StatusCode == http.StatusOK {
+		yamlFile, err = io.ReadAll(resp.Body)
+		if err != nil {
+			return Images{}, err
+		}
+	}
+
+	var platform Platform
+	err = yaml.Unmarshal(yamlFile, &platform)
+	if err != nil {
+		return Images{}, err
+	}
+
+	var imageProps Images
+	for _, v := range platform.Versions {
+		if v.Version == platformVersion {
+			imageProps = v.Images
+		}
+	}
+
+	return imageProps, nil
+}

--- a/internal/shared.go
+++ b/internal/shared.go
@@ -178,7 +178,9 @@ const (
 )
 
 const (
-	IMAGE_MAP_URL = "https://raw.githubusercontent.com/robolaunch/robolaunch/main/platform.yaml"
+	IMAGE_MAP_CONFIG_MAP_NAME      = "platform"
+	IMAGE_MAP_CONFIG_MAP_NAMESPACE = "kube-system"
+	IMAGE_MAP_URL                  = "https://raw.githubusercontent.com/robolaunch/robolaunch/main/platform.yaml"
 )
 
 // Commands for collecting metrics

--- a/internal/shared.go
+++ b/internal/shared.go
@@ -180,6 +180,7 @@ const (
 const (
 	IMAGE_MAP_CONFIG_MAP_NAME      = "platform"
 	IMAGE_MAP_CONFIG_MAP_NAMESPACE = "kube-system"
+	IMAGE_MAP_CONFIG_MAP_DATA_KEY  = "platform.yaml"
 	IMAGE_MAP_URL                  = "https://raw.githubusercontent.com/robolaunch/robolaunch/main/platform.yaml"
 )
 

--- a/pkg/controllers/robot/helpers.go
+++ b/pkg/controllers/robot/helpers.go
@@ -92,7 +92,7 @@ func (r *RobotReconciler) reconcileCheckImage(ctx context.Context, instance *rob
 	}
 
 	if instance.Status.Image == "" {
-		instance.Status.Image, err = nodePkg.GetImage(*node, *instance)
+		instance.Status.Image, err = nodePkg.GetImage(ctx, r.Client, *node, *instance)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
# :herb: PR: Support Querying `platform.yaml` from ConfigMap

## Description

Operator queries image for custom resource by looking
- if it's a ConfigMap named `platform` available in namespace `kube-system`, and has a key `platform.yaml`
- if there are no such ConfigMap, it queries a remote location, which is currently [here](https://github.com/robolaunch/robolaunch/blob/main/platform.yaml)

Closes #171

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How can it be tested?

Create a ConfigMap named `platform` available in namespace `kube-system`, and has a key `platform.yaml`. Switch the image names and create robot each time you switched.
