### PR TITLE
PR: Configure VDI Pod for CPU Use

### DIFF
--- a/internal/configure/encoding.go
+++ b/internal/configure/encoding.go
@@ -1,0 +1,21 @@
+package configure
+
+import (
+	"github.com/robolaunch/robot-operator/internal"
+	robotv1alpha1 "github.com/robolaunch/robot-operator/pkg/api/roboscale.io/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func InjectEncodingOption(pod *corev1.Pod, robot robotv1alpha1.Robot) *corev1.Pod {
+
+	environmentVariables := []corev1.EnvVar{
+		internal.Env("NEKO_HWENC", "nvenc"),
+	}
+
+	for k, container := range pod.Spec.Containers {
+		container.Env = append(container.Env, environmentVariables...)
+		pod.Spec.Containers[k] = container
+	}
+
+	return pod
+}

--- a/internal/resources/robot_vdi.go
+++ b/internal/resources/robot_vdi.go
@@ -155,6 +155,10 @@ func GetRobotVDIPod(robotVDI *robotv1alpha1.RobotVDI, podNamespacedName *types.N
 	configure.InjectPodDisplayConfiguration(vdiPod, *robotVDI)
 	configure.InjectRuntimeClass(vdiPod, robot, node)
 
+	if !robotVDI.Spec.DisableNVENC {
+		configure.InjectEncodingOption(vdiPod, robot)
+	}
+
 	if robot.Spec.Type == robotv1alpha1.TypeRobot {
 		configure.InjectGenericRobotEnvironmentVariables(vdiPod, robot)
 		configure.InjectRMWImplementationConfiguration(vdiPod, robot)

--- a/pkg/api/roboscale.io/v1alpha1/dev_types.go
+++ b/pkg/api/roboscale.io/v1alpha1/dev_types.go
@@ -226,6 +226,8 @@ type RobotVDISpec struct {
 	Resolution string `json:"resolution,omitempty"`
 	// [*alpha*] RobotIDE will create an Ingress resource if `true`.
 	Ingress bool `json:"ingress,omitempty"`
+	// If true, VDI uses plain h264 instead of nvh264enc.
+	DisableNVENC bool `json:"disableNvenc,omitempty"`
 }
 
 // RobotVDIStatus defines the observed state of RobotVDI.


### PR DESCRIPTION
# :herb: PR: Configure VDI Pod for CPU Use

## Description

- `.spec.disableNvenc` option is added to RobotVDI

Closes #173 

## Type of change

- [x] New feature (non-breaking change which adds functionality)