### PR TITLE
PR: Support MIG Instances

### DIFF
--- a/config/crd/bases/robot.roboscale.io_launchmanagers.yaml
+++ b/config/crd/bases/robot.roboscale.io_launchmanagers.yaml
@@ -188,6 +188,11 @@ spec:
                             gpuCore:
                               description: GPU core number that will be allocated.
                               type: integer
+                            gpuInstance:
+                              default: nvidia.com/gpu
+                              description: GPU instance that will be allocated. eg.
+                                nvidia.com/mig-1g.5gb. Defaults to "nvidia.com/gpu".
+                              type: string
                             memory:
                               description: Memory resource limit.
                               pattern: ^([0-9])+(Mi|Gi)$

--- a/config/crd/bases/robot.roboscale.io_robotartifacts.yaml
+++ b/config/crd/bases/robot.roboscale.io_robotartifacts.yaml
@@ -319,6 +319,11 @@ spec:
                           gpuCore:
                             description: GPU core number that will be allocated.
                             type: integer
+                          gpuInstance:
+                            default: nvidia.com/gpu
+                            description: GPU instance that will be allocated. eg.
+                              nvidia.com/mig-1g.5gb. Defaults to "nvidia.com/gpu".
+                            type: string
                           memory:
                             description: Memory resource limit.
                             pattern: ^([0-9])+(Mi|Gi)$
@@ -371,6 +376,11 @@ spec:
                           gpuCore:
                             description: GPU core number that will be allocated.
                             type: integer
+                          gpuInstance:
+                            default: nvidia.com/gpu
+                            description: GPU instance that will be allocated. eg.
+                              nvidia.com/mig-1g.5gb. Defaults to "nvidia.com/gpu".
+                            type: string
                           memory:
                             description: Memory resource limit.
                             pattern: ^([0-9])+(Mi|Gi)$

--- a/config/crd/bases/robot.roboscale.io_robotdevsuites.yaml
+++ b/config/crd/bases/robot.roboscale.io_robotdevsuites.yaml
@@ -129,6 +129,11 @@ spec:
                       gpuCore:
                         description: GPU core number that will be allocated.
                         type: integer
+                      gpuInstance:
+                        default: nvidia.com/gpu
+                        description: GPU instance that will be allocated. eg. nvidia.com/mig-1g.5gb.
+                          Defaults to "nvidia.com/gpu".
+                        type: string
                       memory:
                         description: Memory resource limit.
                         pattern: ^([0-9])+(Mi|Gi)$
@@ -181,6 +186,11 @@ spec:
                       gpuCore:
                         description: GPU core number that will be allocated.
                         type: integer
+                      gpuInstance:
+                        default: nvidia.com/gpu
+                        description: GPU instance that will be allocated. eg. nvidia.com/mig-1g.5gb.
+                          Defaults to "nvidia.com/gpu".
+                        type: string
                       memory:
                         description: Memory resource limit.
                         pattern: ^([0-9])+(Mi|Gi)$

--- a/config/crd/bases/robot.roboscale.io_robotides.yaml
+++ b/config/crd/bases/robot.roboscale.io_robotides.yaml
@@ -73,6 +73,11 @@ spec:
                   gpuCore:
                     description: GPU core number that will be allocated.
                     type: integer
+                  gpuInstance:
+                    default: nvidia.com/gpu
+                    description: GPU instance that will be allocated. eg. nvidia.com/mig-1g.5gb.
+                      Defaults to "nvidia.com/gpu".
+                    type: string
                   memory:
                     description: Memory resource limit.
                     pattern: ^([0-9])+(Mi|Gi)$

--- a/config/crd/bases/robot.roboscale.io_robots.yaml
+++ b/config/crd/bases/robot.roboscale.io_robots.yaml
@@ -340,6 +340,11 @@ spec:
                           gpuCore:
                             description: GPU core number that will be allocated.
                             type: integer
+                          gpuInstance:
+                            default: nvidia.com/gpu
+                            description: GPU instance that will be allocated. eg.
+                              nvidia.com/mig-1g.5gb. Defaults to "nvidia.com/gpu".
+                            type: string
                           memory:
                             description: Memory resource limit.
                             pattern: ^([0-9])+(Mi|Gi)$
@@ -392,6 +397,11 @@ spec:
                           gpuCore:
                             description: GPU core number that will be allocated.
                             type: integer
+                          gpuInstance:
+                            default: nvidia.com/gpu
+                            description: GPU instance that will be allocated. eg.
+                              nvidia.com/mig-1g.5gb. Defaults to "nvidia.com/gpu".
+                            type: string
                           memory:
                             description: Memory resource limit.
                             pattern: ^([0-9])+(Mi|Gi)$

--- a/config/crd/bases/robot.roboscale.io_robotvdis.yaml
+++ b/config/crd/bases/robot.roboscale.io_robotvdis.yaml
@@ -85,6 +85,11 @@ spec:
                   gpuCore:
                     description: GPU core number that will be allocated.
                     type: integer
+                  gpuInstance:
+                    default: nvidia.com/gpu
+                    description: GPU instance that will be allocated. eg. nvidia.com/mig-1g.5gb.
+                      Defaults to "nvidia.com/gpu".
+                    type: string
                   memory:
                     description: Memory resource limit.
                     pattern: ^([0-9])+(Mi|Gi)$

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -4,5 +4,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: robolaunchio/robot-controller-manager
-  newTag: v0.2.6-alpha.2
+  newName: robolaunchio/robot-controller-manager-dev
+  newTag: platform-v0.7.0

--- a/internal/resources/robot_vdi.go
+++ b/internal/resources/robot_vdi.go
@@ -312,7 +312,7 @@ func GetRobotVDIIngress(robotVDI *robotv1alpha1.RobotVDI, ingressNamespacedName 
 func getResourceLimits(resources robotv1alpha1.Resources) corev1.ResourceList {
 	resourceLimits := corev1.ResourceList{}
 	if resources.GPUCore != 0 {
-		resourceLimits["nvidia.com/gpu"] = resource.MustParse(strconv.Itoa(resources.GPUCore))
+		resourceLimits[corev1.ResourceName(resources.GPUInstance)] = resource.MustParse(strconv.Itoa(resources.GPUCore))
 	}
 	if resources.CPU != "" {
 		resourceLimits["cpu"] = resource.MustParse(resources.CPU)

--- a/internal/shared.go
+++ b/internal/shared.go
@@ -31,6 +31,13 @@ const (
 	TARGET_VDI_LABEL_KEY   = "robolaunch.io/target-vdi"
 )
 
+// MIG instance labels eg. mig-1g.5gb
+const (
+	VDI_MIG_INSTANCE_LABEL_KEY           = "robolaunch.io/vdi-mig-instance"
+	IDE_MIG_INSTANCE_LABEL_KEY           = "robolaunch.io/ide-mig-instance"
+	LAUNCHMANAGER_MIG_INSTANCE_LABEL_KEY = "robolaunch.io/lm-mig-instance"
+)
+
 // Special escape labels
 const (
 	ROBOT_DEV_SUITE_OWNED = "robolaunch.io/dev-suite-owned"

--- a/internal/shared.go
+++ b/internal/shared.go
@@ -31,13 +31,6 @@ const (
 	TARGET_VDI_LABEL_KEY   = "robolaunch.io/target-vdi"
 )
 
-// MIG instance labels eg. mig-1g.5gb
-const (
-	VDI_MIG_INSTANCE_LABEL_KEY           = "robolaunch.io/vdi-mig-instance"
-	IDE_MIG_INSTANCE_LABEL_KEY           = "robolaunch.io/ide-mig-instance"
-	LAUNCHMANAGER_MIG_INSTANCE_LABEL_KEY = "robolaunch.io/lm-mig-instance"
-)
-
 // Special escape labels
 const (
 	ROBOT_DEV_SUITE_OWNED = "robolaunch.io/dev-suite-owned"

--- a/pkg/api/roboscale.io/v1alpha1/dev_types.go
+++ b/pkg/api/roboscale.io/v1alpha1/dev_types.go
@@ -191,6 +191,9 @@ type RobotIDEStatus struct {
 
 // VDI resource limits.
 type Resources struct {
+	// GPU instance that will be allocated. eg. mig-1g.5gb. Defaults to "gpu".
+	// +kubebuilder:default="gpu"
+	GPUInstance string `json:"gpuInstance,omitempty"`
 	// GPU core number that will be allocated.
 	GPUCore int `json:"gpuCore,omitempty"`
 	// CPU resource limit.

--- a/pkg/api/roboscale.io/v1alpha1/dev_types.go
+++ b/pkg/api/roboscale.io/v1alpha1/dev_types.go
@@ -191,8 +191,8 @@ type RobotIDEStatus struct {
 
 // VDI resource limits.
 type Resources struct {
-	// GPU instance that will be allocated. eg. mig-1g.5gb. Defaults to "gpu".
-	// +kubebuilder:default="gpu"
+	// GPU instance that will be allocated. eg. nvidia.com/mig-1g.5gb. Defaults to "nvidia.com/gpu".
+	// +kubebuilder:default="nvidia.com/gpu"
 	GPUInstance string `json:"gpuInstance,omitempty"`
 	// GPU core number that will be allocated.
 	GPUCore int `json:"gpuCore,omitempty"`


### PR DESCRIPTION
# :herb: PR: Support MIG Instances

## Description

In resources API, GPU instance type can be specified.

Closes #175 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How can it be tested?

Can be tested by populating `gpuInstance` field on a host that uses MIG instances.