### PR TITLE
PR: Set Timezone

### DIFF
--- a/internal/configure/timezone.go
+++ b/internal/configure/timezone.go
@@ -27,24 +27,15 @@ func (cfg *PodConfigInjector) placeTimezone(pod *corev1.Pod, node corev1.Node) {
 		return
 	}
 
-	volume := corev1.Volume{
-		Name: "tz-config",
-		VolumeSource: corev1.VolumeSource{
-			HostPath: &corev1.HostPathVolumeSource{
-				Path: "/usr/share/zoneinfo/" + timezone.Continent + "/" + timezone.City,
-			},
+	environmentVariables := []corev1.EnvVar{
+		{
+			Name:  "TZ",
+			Value: timezone.Continent + "/" + timezone.City,
 		},
 	}
 
-	pod.Spec.Volumes = append(pod.Spec.Volumes, volume)
-
-	volumeMount := corev1.VolumeMount{
-		Name:      "tz-config",
-		MountPath: "/etc/localtime",
-	}
-
 	for k, container := range pod.Spec.Containers {
-		container.VolumeMounts = append(container.VolumeMounts, volumeMount)
+		container.Env = append(container.Env, environmentVariables...)
 		pod.Spec.Containers[k] = container
 	}
 
@@ -59,24 +50,15 @@ func (cfg *JobConfigInjector) placeTimezone(job *batchv1.Job, node corev1.Node) 
 		return
 	}
 
-	volume := corev1.Volume{
-		Name: "tz-config",
-		VolumeSource: corev1.VolumeSource{
-			HostPath: &corev1.HostPathVolumeSource{
-				Path: "/usr/share/zoneinfo/" + timezone.Continent + "/" + timezone.City,
-			},
+	environmentVariables := []corev1.EnvVar{
+		{
+			Name:  "TZ",
+			Value: timezone.Continent + "/" + timezone.City,
 		},
 	}
 
-	podSpec.Volumes = append(podSpec.Volumes, volume)
-
-	volumeMount := corev1.VolumeMount{
-		Name:      "tz-config",
-		MountPath: "/etc/localtime",
-	}
-
 	for k, container := range podSpec.Containers {
-		container.VolumeMounts = append(container.VolumeMounts, volumeMount)
+		container.Env = append(container.Env, environmentVariables...)
 		podSpec.Containers[k] = container
 	}
 

--- a/internal/configure/timezone.go
+++ b/internal/configure/timezone.go
@@ -2,6 +2,7 @@ package configure
 
 import (
 	"github.com/robolaunch/robot-operator/internal/label"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -10,6 +11,13 @@ func (cfg *PodConfigInjector) InjectTimezone(pod *corev1.Pod, node corev1.Node) 
 	cfg.placeTimezone(pod, node)
 
 	return pod
+}
+
+func (cfg *JobConfigInjector) InjectTimezone(job *batchv1.Job, node corev1.Node) *batchv1.Job {
+
+	cfg.placeTimezone(job, node)
+
+	return job
 }
 
 func (cfg *PodConfigInjector) placeTimezone(pod *corev1.Pod, node corev1.Node) {
@@ -39,5 +47,39 @@ func (cfg *PodConfigInjector) placeTimezone(pod *corev1.Pod, node corev1.Node) {
 		container.VolumeMounts = append(container.VolumeMounts, volumeMount)
 		pod.Spec.Containers[k] = container
 	}
+
+}
+
+func (cfg *JobConfigInjector) placeTimezone(job *batchv1.Job, node corev1.Node) {
+
+	podSpec := job.Spec.Template.Spec
+
+	timezone := label.GetTimezone(&node)
+	if timezone.Continent == "" || timezone.City == "" {
+		return
+	}
+
+	volume := corev1.Volume{
+		Name: "tz-config",
+		VolumeSource: corev1.VolumeSource{
+			HostPath: &corev1.HostPathVolumeSource{
+				Path: "/usr/share/zoneinfo/" + timezone.Continent + "/" + timezone.City,
+			},
+		},
+	}
+
+	podSpec.Volumes = append(podSpec.Volumes, volume)
+
+	volumeMount := corev1.VolumeMount{
+		Name:      "tz-config",
+		MountPath: "/etc/localtime",
+	}
+
+	for k, container := range podSpec.Containers {
+		container.VolumeMounts = append(container.VolumeMounts, volumeMount)
+		podSpec.Containers[k] = container
+	}
+
+	job.Spec.Template.Spec = podSpec
 
 }

--- a/internal/configure/timezone.go
+++ b/internal/configure/timezone.go
@@ -1,0 +1,43 @@
+package configure
+
+import (
+	"github.com/robolaunch/robot-operator/internal/label"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func (cfg *PodConfigInjector) InjectTimezone(pod *corev1.Pod, node corev1.Node) *corev1.Pod {
+
+	cfg.placeTimezone(pod, node)
+
+	return pod
+}
+
+func (cfg *PodConfigInjector) placeTimezone(pod *corev1.Pod, node corev1.Node) {
+
+	timezone := label.GetTimezone(&node)
+	if timezone.Continent == "" || timezone.City == "" {
+		return
+	}
+
+	volume := corev1.Volume{
+		Name: "tz-config",
+		VolumeSource: corev1.VolumeSource{
+			HostPath: &corev1.HostPathVolumeSource{
+				Path: "/usr/share/zoneinfo/" + timezone.Continent + "/" + timezone.City,
+			},
+		},
+	}
+
+	pod.Spec.Volumes = append(pod.Spec.Volumes, volume)
+
+	volumeMount := corev1.VolumeMount{
+		Name:      "tz-config",
+		MountPath: "/etc/localtime",
+	}
+
+	for k, container := range pod.Spec.Containers {
+		container.VolumeMounts = append(container.VolumeMounts, volumeMount)
+		pod.Spec.Containers[k] = container
+	}
+
+}

--- a/internal/label/tenancy.go
+++ b/internal/label/tenancy.go
@@ -14,6 +14,11 @@ type Tenancy struct {
 	PhysicalInstance   string
 }
 
+type Timezone struct {
+	Continent string
+	City      string
+}
+
 func GetTenancy(obj metav1.Object) *Tenancy {
 	tenancy := &Tenancy{}
 	labels := obj.GetLabels()
@@ -43,6 +48,22 @@ func GetTenancy(obj metav1.Object) *Tenancy {
 	}
 
 	return tenancy
+}
+
+func GetTimezone(obj metav1.Object) *Timezone {
+
+	timezone := &Timezone{}
+	labels := obj.GetLabels()
+
+	if continent, ok := labels[internal.TZ_CONTINENT_LABEL_KEY]; ok {
+		timezone.Continent = continent
+	}
+
+	if city, ok := labels[internal.TZ_CITY_LABEL_KEY]; ok {
+		timezone.City = city
+	}
+
+	return timezone
 }
 
 func GetTenancyMap(obj metav1.Object) map[string]string {

--- a/internal/resources/robot_ide.go
+++ b/internal/resources/robot_ide.go
@@ -100,6 +100,7 @@ func GetRobotIDEPod(robotIDE *robotv1alpha1.RobotIDE, podNamespacedName *types.N
 	podCfg.InjectBackgroundConfigFiles(&idePod, cm)
 	podCfg.InjectGenericEnvironmentVariables(&idePod, robot)
 	podCfg.InjectRuntimeClass(&idePod, robot, node)
+	podCfg.InjectTimezone(&idePod, node)
 	if robotIDE.Spec.Display && label.GetTargetRobotVDI(robotIDE) != "" {
 		// TODO: Add control for validating robot VDI
 		podCfg.InjectDisplayConfiguration(&idePod, robotVDI)

--- a/internal/resources/robot_vdi.go
+++ b/internal/resources/robot_vdi.go
@@ -165,6 +165,7 @@ func GetRobotVDIPod(robotVDI *robotv1alpha1.RobotVDI, podNamespacedName *types.N
 	podCfg.InjectDisplayConfiguration(vdiPod, *robotVDI)
 	podCfg.InjectRuntimeClass(vdiPod, robot, node)
 	podCfg.InjectVolumeConfiguration(vdiPod, robot)
+	podCfg.InjectTimezone(vdiPod, node)
 
 	if !robotVDI.Spec.DisableNVENC {
 		podCfg.InjectEncodingOption(vdiPod, robot)

--- a/internal/shared.go
+++ b/internal/shared.go
@@ -17,6 +17,12 @@ const (
 	PHYSICAL_INSTANCE_LABEL_KEY    = "robolaunch.io/physical-instance"
 )
 
+// Timezone labels
+const (
+	TZ_CONTINENT_LABEL_KEY = "robolaunch.io/tz-continent"
+	TZ_CITY_LABEL_KEY      = "robolaunch.io/tz-city"
+)
+
 // Ready robot label
 const (
 	ROBOT_IMAGE_REGISTRY_LABEL_KEY   = "robolaunch.io/robot-image-registry"


### PR DESCRIPTION
# :herb: PR: Set Timezone

## Description

- Timezone is set in applications by checking the node labels:
  - `robolaunch.io/tz-continent`
  - `robolaunch.io/tz-city`

Closes #207 

## Type of change

- [x] This change requires a documentation update

## How can it be tested?

Check the timezone by running `date` in IDE and VDI pods after labeling the node and create an application.
