### PR TITLE
PR: Add Base URL to the File Browser Configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 <a name="unreleased"></a>
 ## [Unreleased]
 
+### Fix
+- **filebrowser:** add file browser base url as env variable to services
+
+
+<a name="v0.2.6-alpha.14.5"></a>
+## [v0.2.6-alpha.14.5] - 2023-12-13
 
 <a name="v0.2.6-alpha.14.4"></a>
 ## [v0.2.6-alpha.14.4] - 2023-12-13
@@ -364,7 +370,8 @@
 - Merge pull request [#24](https://github.com/robolaunch/robot-operator/issues/24) from robolaunch/23-allow-multiple-launches
 
 
-[Unreleased]: https://github.com/robolaunch/robot-operator/compare/v0.2.6-alpha.14.4...HEAD
+[Unreleased]: https://github.com/robolaunch/robot-operator/compare/v0.2.6-alpha.14.5...HEAD
+[v0.2.6-alpha.14.5]: https://github.com/robolaunch/robot-operator/compare/v0.2.6-alpha.14.4...v0.2.6-alpha.14.5
 [v0.2.6-alpha.14.4]: https://github.com/robolaunch/robot-operator/compare/v0.2.6-alpha.14.3...v0.2.6-alpha.14.4
 [v0.2.6-alpha.14.3]: https://github.com/robolaunch/robot-operator/compare/v0.2.6-alpha.14.2...v0.2.6-alpha.14.3
 [v0.2.6-alpha.14.2]: https://github.com/robolaunch/robot-operator/compare/v0.2.6-alpha.14.1...v0.2.6-alpha.14.2

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: robolaunchio/robot-controller-manager
-  newTag: v0.2.6-alpha.14.5
+  newTag: v0.2.6-alpha.14.6

--- a/hack/deploy/chart/robot-operator/Chart.yaml
+++ b/hack/deploy/chart/robot-operator/Chart.yaml
@@ -13,9 +13,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.6-alpha.14.5
+version: 0.2.6-alpha.14.6
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.2.6-alpha.14.5"
+appVersion: "v0.2.6-alpha.14.6"

--- a/hack/deploy/chart/robot-operator/values.yaml
+++ b/hack/deploy/chart/robot-operator/values.yaml
@@ -32,7 +32,7 @@ controllerManager:
         - ALL
     image:
       repository: robolaunchio/robot-controller-manager
-      tag: v0.2.6-alpha.14.5
+      tag: v0.2.6-alpha.14.6
     resources:
       limits:
         cpu: 500m

--- a/hack/deploy/manifests/robot_operator.yaml
+++ b/hack/deploy/manifests/robot_operator.yaml
@@ -6768,7 +6768,7 @@ spec:
             - --leader-elect
           command:
             - /manager
-          image: robolaunchio/robot-controller-manager:v0.2.6-alpha.14.5
+          image: robolaunchio/robot-controller-manager:v0.2.6-alpha.14.6
           livenessProbe:
             httpGet:
               path: /healthz

--- a/internal/resources/robot_ide.go
+++ b/internal/resources/robot_ide.go
@@ -51,6 +51,7 @@ func GetRobotIDEPod(robotIDE *robotv1alpha1.RobotIDE, podNamespacedName *types.N
 			internal.Env("CODE_SERVER_PORT", strconv.Itoa(ROBOT_IDE_PORT)),
 			internal.Env("FILE_BROWSER_PORT", strconv.Itoa(internal.FILE_BROWSER_PORT)),
 			internal.Env("FILE_BROWSER_SERVICE", "code-server"),
+			internal.Env("FILE_BROWSER_BASE_URL", robotv1alpha1.GetRobotServicePath(robot, "/file-browser/ide")),
 			internal.Env("ROBOT_NAMESPACE", robot.Namespace),
 			internal.Env("ROBOT_NAME", robot.Name),
 			internal.Env("WORKSPACES_PATH", robot.Spec.WorkspaceManagerTemplate.WorkspacesPath),

--- a/internal/resources/robot_vdi.go
+++ b/internal/resources/robot_vdi.go
@@ -117,6 +117,7 @@ func GetRobotVDIPod(robotVDI *robotv1alpha1.RobotVDI, podNamespacedName *types.N
 			internal.Env("RESOLUTION", robotVDI.Spec.Resolution),
 			internal.Env("FILE_BROWSER_PORT", strconv.Itoa(internal.FILE_BROWSER_PORT)),
 			internal.Env("FILE_BROWSER_SERVICE", "vdi"),
+			internal.Env("FILE_BROWSER_BASE_URL", robotv1alpha1.GetRobotServicePath(robot, "/file-browser/vdi")),
 		},
 		Stdin: true,
 		TTY:   true,


### PR DESCRIPTION
# :herb: PR: Add Base URL to the File Browser Configuration

## Description

File browser without base URL is not reachable over ingress. In this PR, every container w/ file browser is given an environment variable with key `FILE_BROWSER_BASE_URL` and file browser's supervisord configuration uses this parameter's value.

Closes #209 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How can it be tested?

Can be tested by trying to reach file browser over ingress.