### PR TITLE
PR: Extend Upload Constraints by Setting Proxy Body Size

### DIFF
--- a/internal/resources/notebook.go
+++ b/internal/resources/notebook.go
@@ -311,6 +311,7 @@ func GetNotebookCustomIngress(notebook *robotv1alpha1.Notebook, ingressNamespace
 		internal.INGRESS_NGINX_PROXY_BUFFER_SIZE_KEY: internal.INGRESS_NGINX_PROXY_BUFFER_SIZE_VAL,
 		internal.INGRESS_NGINX_REWRITE_TARGET_KEY:    internal.INGRESS_NGINX_REWRITE_TARGET_VAL,
 		internal.INGRESS_PROXY_READ_TIMEOUT_KEY:      internal.INGRESS_PROXY_READ_TIMEOUT_VAL,
+		internal.INGRESS_NGINX_PROXY_BODY_SIZE_KEY:   internal.INGRESS_NGINX_PROXY_BODY_SIZE_VAL,
 	}
 
 	pathTypePrefix := networkingv1.PathTypePrefix

--- a/internal/resources/relay_server.go
+++ b/internal/resources/relay_server.go
@@ -116,6 +116,7 @@ func GetRelayServerIngress(relayserver *robotv1alpha1.RelayServer, ingressNamesp
 		internal.INGRESS_NGINX_PROXY_BUFFER_SIZE_KEY: internal.INGRESS_NGINX_PROXY_BUFFER_SIZE_VAL,
 		internal.INGRESS_NGINX_REWRITE_TARGET_KEY:    internal.INGRESS_NGINX_REWRITE_TARGET_VAL,
 		internal.INGRESS_PROXY_READ_TIMEOUT_KEY:      internal.INGRESS_PROXY_READ_TIMEOUT_VAL,
+		internal.INGRESS_NGINX_PROXY_BODY_SIZE_KEY:   internal.INGRESS_NGINX_PROXY_BODY_SIZE_VAL,
 	}
 
 	pathTypePrefix := networkingv1.PathTypePrefix

--- a/internal/resources/robot_ide.go
+++ b/internal/resources/robot_ide.go
@@ -183,6 +183,7 @@ func GetRobotIDEIngress(robotIDE *robotv1alpha1.RobotIDE, ingressNamespacedName 
 		internal.INGRESS_NGINX_PROXY_BUFFER_SIZE_KEY: internal.INGRESS_NGINX_PROXY_BUFFER_SIZE_VAL,
 		internal.INGRESS_NGINX_REWRITE_TARGET_KEY:    internal.INGRESS_NGINX_REWRITE_TARGET_VAL,
 		internal.INGRESS_PROXY_READ_TIMEOUT_KEY:      internal.INGRESS_PROXY_READ_TIMEOUT_VAL,
+		internal.INGRESS_NGINX_PROXY_BODY_SIZE_KEY:   internal.INGRESS_NGINX_PROXY_BODY_SIZE_VAL,
 	}
 
 	pathTypePrefix := networkingv1.PathTypePrefix

--- a/internal/resources/robot_vdi.go
+++ b/internal/resources/robot_vdi.go
@@ -280,6 +280,7 @@ func GetRobotVDIIngress(robotVDI *robotv1alpha1.RobotVDI, ingressNamespacedName 
 		internal.INGRESS_NGINX_PROXY_BUFFERS_NUMBER_KEY: internal.INGRESS_VDI_NGINX_PROXY_BUFFERS_NUMBER_VAL,
 		internal.INGRESS_NGINX_REWRITE_TARGET_KEY:       internal.INGRESS_NGINX_REWRITE_TARGET_VAL,
 		internal.INGRESS_PROXY_READ_TIMEOUT_KEY:         internal.INGRESS_PROXY_READ_TIMEOUT_VAL,
+		internal.INGRESS_NGINX_PROXY_BODY_SIZE_KEY:      internal.INGRESS_NGINX_PROXY_BODY_SIZE_VAL,
 	}
 
 	pathTypePrefix := networkingv1.PathTypePrefix

--- a/internal/shared.go
+++ b/internal/shared.go
@@ -188,6 +188,8 @@ const (
 	INGRESS_VDI_NGINX_PROXY_BUFFERS_NUMBER_VAL = "4"
 	INGRESS_NGINX_REWRITE_TARGET_KEY           = "nginx.ingress.kubernetes.io/rewrite-target"
 	INGRESS_NGINX_REWRITE_TARGET_VAL           = "/$2"
+	INGRESS_NGINX_PROXY_BODY_SIZE_KEY          = "nginx.ingress.kubernetes.io/proxy-body-size"
+	INGRESS_NGINX_PROXY_BODY_SIZE_VAL          = "900m"
 
 	INGRESS_IDE_CONFIGURATION_SNIPPET_VAL = "" +
 		"auth_request_set $name_upstream_1 $upstream_cookie_name_1;" +


### PR DESCRIPTION
# :herb: PR: Extend Upload Constraints by Setting Proxy Body Size

## Description

CRDs that their ingress resources are affected by change:
- RobotIDE
- RobotVDI
- Notebook
- RelayServer

Closes #219 