### PR TITLE
PR: Manage Lifecycle of StatefulSet(s) of ROS2Workload

### DIFF
--- a/config/crd/bases/robot.roboscale.io_ros2bridges.yaml
+++ b/config/crd/bases/robot.roboscale.io_ros2bridges.yaml
@@ -33,7 +33,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: ROS2BridgeSpec defines the desired state of ROS2Bridge.
+            description: Specification of the desired behavior of the ROS2Bridge.
             properties:
               discoveryServerRef:
                 description: Object reference to DiscoveryServer.
@@ -97,7 +97,7 @@ spec:
             - distro
             type: object
           status:
-            description: ROS2BridgeStatus defines the observed state of ROS2Bridge.
+            description: Most recently observed status of the ROS2Bridge.
             properties:
               connectionInfo:
                 description: Connection info obtained from DiscoveryServer.

--- a/config/crd/bases/robot.roboscale.io_ros2workloads.yaml
+++ b/config/crd/bases/robot.roboscale.io_ros2workloads.yaml
@@ -33,7 +33,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: ROS2WorkloadSpec defines the desired state of ROS2Workload.
+            description: Specification of the desired behavior of the ROS2Workload.
             properties:
               containers:
                 description: Configurational parameters for containers that will be
@@ -1690,7 +1690,7 @@ spec:
             - discoveryServerTemplate
             type: object
           status:
-            description: ROS2WorkloadStatus defines the observed state of ROS2Workload.
+            description: Most recently observed status of the ROS2Workload.
             properties:
               discoveryServerStatus:
                 description: Discovery server instance status.

--- a/internal/configure/v1alpha2/configure.go
+++ b/internal/configure/v1alpha2/configure.go
@@ -1,7 +1,3 @@
 package configure
 
-type StatefulSetConfigInjector struct{}
-type JobConfigInjector struct{}
-type PodConfigInjector struct{}
-type ContainerConfigInjector struct{}
-type ServiceConfigInjector struct{}
+type PodSpecConfigInjector struct{}

--- a/internal/configure/v1alpha2/discovery_server.go
+++ b/internal/configure/v1alpha2/discovery_server.go
@@ -5,15 +5,12 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-func (cfg *PodConfigInjector) InjectDiscoveryServerConnection(pod *corev1.Pod, connectionInfo robotv1alpha1.ConnectionInfo) *corev1.Pod {
-
-	cfg.placeDiscoveryServerEnvironmentVariables(pod, connectionInfo)
-	cfg.placeDiscoveryServerConfigFile(pod, connectionInfo)
-
-	return pod
+func (cfg *PodSpecConfigInjector) InjectDiscoveryServerConnection(podSpec *corev1.PodSpec, connectionInfo robotv1alpha1.ConnectionInfo) {
+	cfg.placeDiscoveryServerEnvironmentVariables(podSpec, connectionInfo)
+	cfg.placeDiscoveryServerConfigFile(podSpec, connectionInfo)
 }
 
-func (cfg *PodConfigInjector) placeDiscoveryServerEnvironmentVariables(pod *corev1.Pod, connectionInfo robotv1alpha1.ConnectionInfo) {
+func (cfg *PodSpecConfigInjector) placeDiscoveryServerEnvironmentVariables(podSpec *corev1.PodSpec, connectionInfo robotv1alpha1.ConnectionInfo) {
 
 	environmentVariables := []corev1.EnvVar{
 		{
@@ -29,14 +26,14 @@ func (cfg *PodConfigInjector) placeDiscoveryServerEnvironmentVariables(pod *core
 		},
 	}
 
-	for k, container := range pod.Spec.Containers {
+	for k, container := range podSpec.Containers {
 		container.Env = append(container.Env, environmentVariables...)
-		pod.Spec.Containers[k] = container
+		podSpec.Containers[k] = container
 	}
 
 }
 
-func (cfg *PodConfigInjector) placeDiscoveryServerConfigFile(pod *corev1.Pod, connectionInfo robotv1alpha1.ConnectionInfo) {
+func (cfg *PodSpecConfigInjector) placeDiscoveryServerConfigFile(podSpec *corev1.PodSpec, connectionInfo robotv1alpha1.ConnectionInfo) {
 
 	var mode int32 = 511
 
@@ -58,16 +55,16 @@ func (cfg *PodConfigInjector) placeDiscoveryServerConfigFile(pod *corev1.Pod, co
 		},
 	}
 
-	pod.Spec.Volumes = append(pod.Spec.Volumes, volume)
+	podSpec.Volumes = append(podSpec.Volumes, volume)
 
 	volumeMount := corev1.VolumeMount{
 		Name:      "discovery-server",
 		MountPath: "/etc/discovery-server/",
 	}
 
-	for k, container := range pod.Spec.Containers {
+	for k, container := range podSpec.Containers {
 		container.VolumeMounts = append(container.VolumeMounts, volumeMount)
-		pod.Spec.Containers[k] = container
+		podSpec.Containers[k] = container
 	}
 
 }

--- a/internal/configure/v1alpha2/domain_id.go
+++ b/internal/configure/v1alpha2/domain_id.go
@@ -1,0 +1,30 @@
+package configure
+
+import (
+	"strconv"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+func (cfg *PodConfigInjector) InjectROSDomainID(pod *corev1.Pod, domainID int) *corev1.Pod {
+
+	cfg.placeROSDomainIDEnvironmentVariables(pod, domainID)
+
+	return pod
+}
+
+func (cfg *PodConfigInjector) placeROSDomainIDEnvironmentVariables(pod *corev1.Pod, domainID int) {
+
+	environmentVariables := []corev1.EnvVar{
+		{
+			Name:  "ROS_DOMAIN_ID",
+			Value: strconv.Itoa(domainID),
+		},
+	}
+
+	for k, container := range pod.Spec.Containers {
+		container.Env = append(container.Env, environmentVariables...)
+		pod.Spec.Containers[k] = container
+	}
+
+}

--- a/internal/configure/v1alpha2/domain_id.go
+++ b/internal/configure/v1alpha2/domain_id.go
@@ -6,14 +6,11 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-func (cfg *PodConfigInjector) InjectROSDomainID(pod *corev1.Pod, domainID int) *corev1.Pod {
-
-	cfg.placeROSDomainIDEnvironmentVariables(pod, domainID)
-
-	return pod
+func (cfg *PodSpecConfigInjector) InjectROSDomainID(podSpec *corev1.PodSpec, domainID int) {
+	cfg.placeROSDomainIDEnvironmentVariables(podSpec, domainID)
 }
 
-func (cfg *PodConfigInjector) placeROSDomainIDEnvironmentVariables(pod *corev1.Pod, domainID int) {
+func (cfg *PodSpecConfigInjector) placeROSDomainIDEnvironmentVariables(podSpec *corev1.PodSpec, domainID int) {
 
 	environmentVariables := []corev1.EnvVar{
 		{
@@ -22,9 +19,9 @@ func (cfg *PodConfigInjector) placeROSDomainIDEnvironmentVariables(pod *corev1.P
 		},
 	}
 
-	for k, container := range pod.Spec.Containers {
+	for k, container := range podSpec.Containers {
 		container.Env = append(container.Env, environmentVariables...)
-		pod.Spec.Containers[k] = container
+		podSpec.Containers[k] = container
 	}
 
 }

--- a/internal/configure/v1alpha2/image_pull_policy.go
+++ b/internal/configure/v1alpha2/image_pull_policy.go
@@ -1,0 +1,26 @@
+package configure
+
+import (
+	corev1 "k8s.io/api/core/v1"
+)
+
+func (cfg *PodConfigInjector) InjectImagePullPolicy(pod *corev1.Pod) *corev1.Pod {
+
+	cfg.placeImagePullPolicy(pod)
+
+	return pod
+}
+
+func (cfg *PodConfigInjector) placeImagePullPolicy(pod *corev1.Pod) {
+
+	for k, container := range pod.Spec.Containers {
+		container.ImagePullPolicy = corev1.PullIfNotPresent
+		pod.Spec.Containers[k] = container
+	}
+
+	for k, container := range pod.Spec.InitContainers {
+		container.ImagePullPolicy = corev1.PullIfNotPresent
+		pod.Spec.InitContainers[k] = container
+	}
+
+}

--- a/internal/configure/v1alpha2/image_pull_policy.go
+++ b/internal/configure/v1alpha2/image_pull_policy.go
@@ -4,23 +4,20 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-func (cfg *PodConfigInjector) InjectImagePullPolicy(pod *corev1.Pod) *corev1.Pod {
-
-	cfg.placeImagePullPolicy(pod)
-
-	return pod
+func (cfg *PodSpecConfigInjector) InjectImagePullPolicy(podSpec *corev1.PodSpec) {
+	cfg.placeImagePullPolicy(podSpec)
 }
 
-func (cfg *PodConfigInjector) placeImagePullPolicy(pod *corev1.Pod) {
+func (cfg *PodSpecConfigInjector) placeImagePullPolicy(podSpec *corev1.PodSpec) {
 
-	for k, container := range pod.Spec.Containers {
+	for k, container := range podSpec.Containers {
 		container.ImagePullPolicy = corev1.PullIfNotPresent
-		pod.Spec.Containers[k] = container
+		podSpec.Containers[k] = container
 	}
 
-	for k, container := range pod.Spec.InitContainers {
+	for k, container := range podSpec.InitContainers {
 		container.ImagePullPolicy = corev1.PullIfNotPresent
-		pod.Spec.InitContainers[k] = container
+		podSpec.InitContainers[k] = container
 	}
 
 }

--- a/internal/configure/v1alpha2/rmw_implementation.go
+++ b/internal/configure/v1alpha2/rmw_implementation.go
@@ -1,0 +1,20 @@
+package configure
+
+import (
+	"github.com/robolaunch/robot-operator/internal"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func (cfg *PodConfigInjector) InjectRMWImplementationConfiguration(pod *corev1.Pod, rmwImplementation string) *corev1.Pod {
+
+	environmentVariables := []corev1.EnvVar{
+		internal.Env("RMW_IMPLEMENTATION", rmwImplementation),
+	}
+
+	for k, container := range pod.Spec.Containers {
+		container.Env = append(container.Env, environmentVariables...)
+		pod.Spec.Containers[k] = container
+	}
+
+	return pod
+}

--- a/internal/configure/v1alpha2/rmw_implementation.go
+++ b/internal/configure/v1alpha2/rmw_implementation.go
@@ -5,16 +5,13 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-func (cfg *PodConfigInjector) InjectRMWImplementationConfiguration(pod *corev1.Pod, rmwImplementation string) *corev1.Pod {
-
+func (cfg *PodSpecConfigInjector) InjectRMWImplementationConfiguration(podSpec *corev1.PodSpec, rmwImplementation string) {
 	environmentVariables := []corev1.EnvVar{
 		internal.Env("RMW_IMPLEMENTATION", rmwImplementation),
 	}
 
-	for k, container := range pod.Spec.Containers {
+	for k, container := range podSpec.Containers {
 		container.Env = append(container.Env, environmentVariables...)
-		pod.Spec.Containers[k] = container
+		podSpec.Containers[k] = container
 	}
-
-	return pod
 }

--- a/internal/configure/v1alpha2/runtime_class.go
+++ b/internal/configure/v1alpha2/runtime_class.go
@@ -1,0 +1,28 @@
+package configure
+
+import (
+	"github.com/robolaunch/robot-operator/internal/label"
+	"github.com/robolaunch/robot-operator/internal/node"
+	"github.com/robolaunch/robot-operator/pkg/api/roboscale.io/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func (cfg *PodConfigInjector) InjectRuntimeClass(pod *corev1.Pod, robot v1alpha1.Robot, currentNode corev1.Node) *corev1.Pod {
+
+	if label.GetInstanceType(&robot) == label.InstanceTypeCloudInstance && node.IsK3s(currentNode) {
+		nvidiaRuntimeClass := "nvidia"
+		pod.Spec.RuntimeClassName = &nvidiaRuntimeClass
+	}
+
+	return pod
+}
+
+func (cfg *PodConfigInjector) InjectRuntimeClassForMetricsExporter(pod *corev1.Pod, currentNode corev1.Node) *corev1.Pod {
+
+	if node.IsK3s(currentNode) {
+		nvidiaRuntimeClass := "nvidia"
+		pod.Spec.RuntimeClassName = &nvidiaRuntimeClass
+	}
+
+	return pod
+}

--- a/internal/configure/v1alpha2/runtime_class.go
+++ b/internal/configure/v1alpha2/runtime_class.go
@@ -3,12 +3,12 @@ package configure
 import (
 	"github.com/robolaunch/robot-operator/internal/label"
 	"github.com/robolaunch/robot-operator/internal/node"
-	"github.com/robolaunch/robot-operator/pkg/api/roboscale.io/v1alpha1"
+	"github.com/robolaunch/robot-operator/pkg/api/roboscale.io/v1alpha2"
 	corev1 "k8s.io/api/core/v1"
 )
 
-func (cfg *PodSpecConfigInjector) InjectRuntimeClass(podSpec *corev1.PodSpec, robot v1alpha1.Robot, currentNode corev1.Node) {
-	if label.GetInstanceType(&robot) == label.InstanceTypeCloudInstance && node.IsK3s(currentNode) {
+func (cfg *PodSpecConfigInjector) InjectRuntimeClass(podSpec *corev1.PodSpec, ros2Workload v1alpha2.ROS2Workload, currentNode corev1.Node) {
+	if label.GetInstanceType(&ros2Workload) == label.InstanceTypeCloudInstance && node.IsK3s(currentNode) {
 		nvidiaRuntimeClass := "nvidia"
 		podSpec.RuntimeClassName = &nvidiaRuntimeClass
 	}

--- a/internal/configure/v1alpha2/runtime_class.go
+++ b/internal/configure/v1alpha2/runtime_class.go
@@ -7,22 +7,9 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-func (cfg *PodConfigInjector) InjectRuntimeClass(pod *corev1.Pod, robot v1alpha1.Robot, currentNode corev1.Node) *corev1.Pod {
-
+func (cfg *PodSpecConfigInjector) InjectRuntimeClass(podSpec *corev1.PodSpec, robot v1alpha1.Robot, currentNode corev1.Node) {
 	if label.GetInstanceType(&robot) == label.InstanceTypeCloudInstance && node.IsK3s(currentNode) {
 		nvidiaRuntimeClass := "nvidia"
-		pod.Spec.RuntimeClassName = &nvidiaRuntimeClass
+		podSpec.RuntimeClassName = &nvidiaRuntimeClass
 	}
-
-	return pod
-}
-
-func (cfg *PodConfigInjector) InjectRuntimeClassForMetricsExporter(pod *corev1.Pod, currentNode corev1.Node) *corev1.Pod {
-
-	if node.IsK3s(currentNode) {
-		nvidiaRuntimeClass := "nvidia"
-		pod.Spec.RuntimeClassName = &nvidiaRuntimeClass
-	}
-
-	return pod
 }

--- a/internal/configure/v1alpha2/schedule.go
+++ b/internal/configure/v1alpha2/schedule.go
@@ -6,9 +6,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func (cfg *PodConfigInjector) SchedulePod(pod *corev1.Pod, obj metav1.Object) *corev1.Pod {
-
-	pod.Spec.NodeSelector = label.GetTenancyMap(obj)
-
-	return pod
+func (cfg *PodSpecConfigInjector) SchedulePod(podSpec *corev1.PodSpec, obj metav1.Object) {
+	podSpec.NodeSelector = label.GetTenancyMap(obj)
 }

--- a/internal/configure/v1alpha2/schedule.go
+++ b/internal/configure/v1alpha2/schedule.go
@@ -1,0 +1,14 @@
+package configure
+
+import (
+	"github.com/robolaunch/robot-operator/internal/label"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func (cfg *PodConfigInjector) SchedulePod(pod *corev1.Pod, obj metav1.Object) *corev1.Pod {
+
+	pod.Spec.NodeSelector = label.GetTenancyMap(obj)
+
+	return pod
+}

--- a/internal/configure/v1alpha2/timezone.go
+++ b/internal/configure/v1alpha2/timezone.go
@@ -1,0 +1,34 @@
+package configure
+
+import (
+	"github.com/robolaunch/robot-operator/internal/label"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func (cfg *PodConfigInjector) InjectTimezone(pod *corev1.Pod, node corev1.Node) *corev1.Pod {
+
+	cfg.placeTimezone(pod, node)
+
+	return pod
+}
+
+func (cfg *PodConfigInjector) placeTimezone(pod *corev1.Pod, node corev1.Node) {
+
+	timezone := label.GetTimezone(&node)
+	if timezone.Continent == "" || timezone.City == "" {
+		return
+	}
+
+	environmentVariables := []corev1.EnvVar{
+		{
+			Name:  "TZ",
+			Value: timezone.Continent + "/" + timezone.City,
+		},
+	}
+
+	for k, container := range pod.Spec.Containers {
+		container.Env = append(container.Env, environmentVariables...)
+		pod.Spec.Containers[k] = container
+	}
+
+}

--- a/internal/configure/v1alpha2/timezone.go
+++ b/internal/configure/v1alpha2/timezone.go
@@ -5,14 +5,11 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-func (cfg *PodConfigInjector) InjectTimezone(pod *corev1.Pod, node corev1.Node) *corev1.Pod {
-
-	cfg.placeTimezone(pod, node)
-
-	return pod
+func (cfg *PodSpecConfigInjector) InjectTimezone(podSpec *corev1.PodSpec, node corev1.Node) {
+	cfg.placeTimezone(podSpec, node)
 }
 
-func (cfg *PodConfigInjector) placeTimezone(pod *corev1.Pod, node corev1.Node) {
+func (cfg *PodSpecConfigInjector) placeTimezone(podSpec *corev1.PodSpec, node corev1.Node) {
 
 	timezone := label.GetTimezone(&node)
 	if timezone.Continent == "" || timezone.City == "" {
@@ -26,9 +23,9 @@ func (cfg *PodConfigInjector) placeTimezone(pod *corev1.Pod, node corev1.Node) {
 		},
 	}
 
-	for k, container := range pod.Spec.Containers {
+	for k, container := range podSpec.Containers {
 		container.Env = append(container.Env, environmentVariables...)
-		pod.Spec.Containers[k] = container
+		podSpec.Containers[k] = container
 	}
 
 }

--- a/internal/configure/v1alpha2/volume.go
+++ b/internal/configure/v1alpha2/volume.go
@@ -2,17 +2,16 @@ package configure
 
 import (
 	robotv1alpha2 "github.com/robolaunch/robot-operator/pkg/api/roboscale.io/v1alpha2"
-	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 )
 
-func (cfg *StatefulSetConfigInjector) InjectVolumeConfiguration(statefulSet *appsv1.StatefulSet, ros2Workload robotv1alpha2.ROS2Workload) {
-	cfg.injectOwnedPVCVolumes(statefulSet, ros2Workload)
+func (cfg *PodConfigInjector) InjectVolumeConfiguration(pod *corev1.Pod, ros2Workload robotv1alpha2.ROS2Workload) {
+	cfg.injectOwnedPVCVolumes(pod, ros2Workload)
 }
 
-func (cfg *StatefulSetConfigInjector) injectOwnedPVCVolumes(statefulSet *appsv1.StatefulSet, ros2Workload robotv1alpha2.ROS2Workload) {
+func (cfg *PodConfigInjector) injectOwnedPVCVolumes(pod *corev1.Pod, ros2Workload robotv1alpha2.ROS2Workload) {
 	for _, pvcStatus := range ros2Workload.Status.PVCStatuses {
-		statefulSet.Spec.Template.Spec.Volumes = append(statefulSet.Spec.Template.Spec.Volumes, corev1.Volume{
+		pod.Spec.Volumes = append(pod.Spec.Volumes, corev1.Volume{
 			Name: pvcStatus.Resource.Reference.Name,
 			VolumeSource: corev1.VolumeSource{
 				PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{

--- a/internal/configure/v1alpha2/volume.go
+++ b/internal/configure/v1alpha2/volume.go
@@ -5,13 +5,13 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-func (cfg *PodConfigInjector) InjectVolumeConfiguration(pod *corev1.Pod, ros2Workload robotv1alpha2.ROS2Workload) {
-	cfg.injectOwnedPVCVolumes(pod, ros2Workload)
+func (cfg *PodSpecConfigInjector) InjectVolumeConfiguration(podSpec *corev1.PodSpec, ros2Workload robotv1alpha2.ROS2Workload) {
+	cfg.injectOwnedPVCVolumes(podSpec, ros2Workload)
 }
 
-func (cfg *PodConfigInjector) injectOwnedPVCVolumes(pod *corev1.Pod, ros2Workload robotv1alpha2.ROS2Workload) {
+func (cfg *PodSpecConfigInjector) injectOwnedPVCVolumes(podSpec *corev1.PodSpec, ros2Workload robotv1alpha2.ROS2Workload) {
 	for _, pvcStatus := range ros2Workload.Status.PVCStatuses {
-		pod.Spec.Volumes = append(pod.Spec.Volumes, corev1.Volume{
+		podSpec.Volumes = append(podSpec.Volumes, corev1.Volume{
 			Name: pvcStatus.Resource.Reference.Name,
 			VolumeSource: corev1.VolumeSource{
 				PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{

--- a/internal/resources/v1alpha2/ros2_workload.go
+++ b/internal/resources/v1alpha2/ros2_workload.go
@@ -6,6 +6,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
+	"github.com/robolaunch/robot-operator/internal"
 	configure "github.com/robolaunch/robot-operator/internal/configure/v1alpha2"
 	robotv1alpha1 "github.com/robolaunch/robot-operator/pkg/api/roboscale.io/v1alpha1"
 	robotv1alpha2 "github.com/robolaunch/robot-operator/pkg/api/roboscale.io/v1alpha2"
@@ -87,7 +88,17 @@ func GetStatefulSet(ros2Workload *robotv1alpha2.ROS2Workload, ssNamespacedName *
 		},
 		Spec: appsv1.StatefulSetSpec{
 			Replicas: ros2Workload.Spec.Containers[key].Replicas,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					internal.ROS2_WORKLOAD_CONTAINER_SELECTOR_LABEL_KEY: container.Container.Name,
+				},
+			},
 			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						internal.ROS2_WORKLOAD_CONTAINER_SELECTOR_LABEL_KEY: container.Container.Name,
+					},
+				},
 				Spec: podSpec,
 			},
 		},

--- a/internal/shared.go
+++ b/internal/shared.go
@@ -18,6 +18,11 @@ const (
 	DOMAIN_LABEL_KEY               = "robolaunch.io/domain"
 )
 
+// Selector labels
+const (
+	ROS2_WORKLOAD_CONTAINER_SELECTOR_LABEL_KEY = "robolaunch.io/ros2-workload-container"
+)
+
 // Timezone labels
 const (
 	TZ_CONTINENT_LABEL_KEY = "robolaunch.io/tz-continent"

--- a/pkg/api/roboscale.io/v1alpha2/phases.go
+++ b/pkg/api/roboscale.io/v1alpha2/phases.go
@@ -6,6 +6,7 @@ const (
 	ROS2WorkloadPhaseCreatingDiscoveryServer ROS2WorkloadPhase = "CreatingDiscoveryServer"
 	ROS2WorkloadPhaseCreatingROS2Bridge      ROS2WorkloadPhase = "CreatingROS2Bridge"
 	ROS2WorkloadPhaseCreatingPVCs            ROS2WorkloadPhase = "CreatingPVCs"
+	ROS2WorkloadPhaseCreatingStatefulSets    ROS2WorkloadPhase = "CreatingStatefulSets"
 	ROS2WorkloadPhaseReady                   ROS2WorkloadPhase = "Ready"
 )
 

--- a/pkg/controllers/v1alpha2/production/ros2_workload/create.go
+++ b/pkg/controllers/v1alpha2/production/ros2_workload/create.go
@@ -69,3 +69,29 @@ func (r *ROS2WorkloadReconciler) createPersistentVolumeClaim(ctx context.Context
 	logger.Info("STATUS: PVC " + instance.GetPersistentVolumeClaimMetadata(key).Name + " is created.")
 	return nil
 }
+
+// o zaman implement
+func (r *ROS2WorkloadReconciler) createStatefulSet(ctx context.Context, instance *robotv1alpha2.ROS2Workload, key int) error {
+
+	node, err := r.reconcileGetNode(ctx, instance)
+	if err != nil {
+		return err
+	}
+
+	statefulSet := v1alpha2_resources.GetStatefulSet(instance, instance.GetStatefulSetMetadata(key), key, *node)
+
+	err = ctrl.SetControllerReference(instance, statefulSet, r.Scheme)
+	if err != nil {
+		return err
+	}
+
+	err = r.Create(ctx, statefulSet)
+	if err != nil && errors.IsAlreadyExists(err) {
+		return nil
+	} else if err != nil {
+		return err
+	}
+
+	logger.Info("STATUS: StatefulSet " + instance.GetStatefulSetMetadata(key).Name + " is created.")
+	return nil
+}

--- a/pkg/controllers/v1alpha2/production/ros2_workload/create.go
+++ b/pkg/controllers/v1alpha2/production/ros2_workload/create.go
@@ -70,7 +70,6 @@ func (r *ROS2WorkloadReconciler) createPersistentVolumeClaim(ctx context.Context
 	return nil
 }
 
-// o zaman implement
 func (r *ROS2WorkloadReconciler) createStatefulSet(ctx context.Context, instance *robotv1alpha2.ROS2Workload, key int) error {
 
 	node, err := r.reconcileGetNode(ctx, instance)

--- a/pkg/controllers/v1alpha2/production/ros2_workload/handle.go
+++ b/pkg/controllers/v1alpha2/production/ros2_workload/handle.go
@@ -80,7 +80,7 @@ func (r *ROS2WorkloadReconciler) reconcileHandleStatefulSets(ctx context.Context
 		volumesReady = volumesReady && pvcStatus.Resource.Created
 	}
 
-	if volumesReady {
+	if instance.Status.DiscoveryServerStatus.Status.ConfigMapStatus.Created && volumesReady {
 		for key, ssStatus := range instance.Status.StatefulSetStatuses {
 			if !ssStatus.Resource.Created {
 

--- a/pkg/controllers/v1alpha2/production/ros2_workload/helpers.go
+++ b/pkg/controllers/v1alpha2/production/ros2_workload/helpers.go
@@ -3,9 +3,15 @@ package ros2_workload
 import (
 	"context"
 
+	robotErr "github.com/robolaunch/robot-operator/internal/error"
+	"github.com/robolaunch/robot-operator/internal/label"
 	robotv1alpha2 "github.com/robolaunch/robot-operator/pkg/api/roboscale.io/v1alpha2"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/retry"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func (r *ROS2WorkloadReconciler) reconcileGetInstance(ctx context.Context, meta types.NamespacedName) (*robotv1alpha2.ROS2Workload, error) {
@@ -33,4 +39,44 @@ func (r *ROS2WorkloadReconciler) reconcileUpdateInstanceStatus(ctx context.Conte
 		err1 := r.Status().Update(ctx, instance)
 		return err1
 	})
+}
+
+func (r *ROS2WorkloadReconciler) reconcileGetNode(ctx context.Context, instance *robotv1alpha2.ROS2Workload) (*corev1.Node, error) {
+
+	tenancyMap := label.GetTenancyMap(instance)
+
+	requirements := []labels.Requirement{}
+	for k, v := range tenancyMap {
+		newReq, err := labels.NewRequirement(k, selection.In, []string{v})
+		if err != nil {
+			return nil, err
+		}
+		requirements = append(requirements, *newReq)
+	}
+
+	nodeSelector := labels.NewSelector().Add(requirements...)
+
+	nodes := &corev1.NodeList{}
+	err := r.List(ctx, nodes, &client.ListOptions{
+		LabelSelector: nodeSelector,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	if len(nodes.Items) == 0 {
+		return nil, &robotErr.NodeNotFoundError{
+			ResourceKind:      instance.Kind,
+			ResourceName:      instance.Name,
+			ResourceNamespace: instance.Namespace,
+		}
+	} else if len(nodes.Items) > 1 {
+		return nil, &robotErr.MultipleNodeFoundError{
+			ResourceKind:      instance.Kind,
+			ResourceName:      instance.Name,
+			ResourceNamespace: instance.Namespace,
+		}
+	}
+
+	return &nodes.Items[0], nil
 }

--- a/pkg/controllers/v1alpha2/production/ros2_workload/ros2workload_controller.go
+++ b/pkg/controllers/v1alpha2/production/ros2_workload/ros2workload_controller.go
@@ -118,6 +118,11 @@ func (r *ROS2WorkloadReconciler) reconcileCheckStatus(ctx context.Context, insta
 		return robotErr.CheckCreatingOrWaitingError(result, err)
 	}
 
+	err = r.reconcileHandleStatefulSets(ctx, instance)
+	if err != nil {
+		return robotErr.CheckCreatingOrWaitingError(result, err)
+	}
+
 	return nil
 }
 

--- a/pkg/controllers/v1alpha2/production/ros2_workload/ros2workload_controller.go
+++ b/pkg/controllers/v1alpha2/production/ros2_workload/ros2workload_controller.go
@@ -143,6 +143,11 @@ func (r *ROS2WorkloadReconciler) reconcileCheckResources(ctx context.Context, in
 		return err
 	}
 
+	err = r.reconcileCheckStatefulSets(ctx, instance)
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/pkg/controllers/v1alpha2/production/ros2_workload/update.go
+++ b/pkg/controllers/v1alpha2/production/ros2_workload/update.go
@@ -1,0 +1,76 @@
+package ros2_workload
+
+import (
+	"context"
+
+	v1alpha2_resources "github.com/robolaunch/robot-operator/internal/resources/v1alpha2"
+	"k8s.io/apimachinery/pkg/api/errors"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	robotv1alpha2 "github.com/robolaunch/robot-operator/pkg/api/roboscale.io/v1alpha2"
+)
+
+func (r *ROS2WorkloadReconciler) updateDiscoveryServer(ctx context.Context, instance *robotv1alpha2.ROS2Workload) error {
+
+	discoveryServer := v1alpha2_resources.GetDiscoveryServer(instance, instance.GetDiscoveryServerMetadata())
+
+	err := ctrl.SetControllerReference(instance, discoveryServer, r.Scheme)
+	if err != nil {
+		return err
+	}
+
+	err = r.Update(ctx, discoveryServer)
+	if err != nil && errors.IsAlreadyExists(err) {
+		return nil
+	} else if err != nil {
+		return err
+	}
+
+	logger.Info("STATUS: Discovery server " + discoveryServer.Name + " is updated.")
+	return nil
+}
+
+func (r *ROS2WorkloadReconciler) updateROS2Bridge(ctx context.Context, instance *robotv1alpha2.ROS2Workload) error {
+
+	ros2Bridge := v1alpha2_resources.GetROS2Bridge(instance, instance.GetROS2BridgeMetadata())
+
+	err := ctrl.SetControllerReference(instance, ros2Bridge, r.Scheme)
+	if err != nil {
+		return err
+	}
+
+	err = r.Update(ctx, ros2Bridge)
+	if err != nil && errors.IsAlreadyExists(err) {
+		return nil
+	} else if err != nil {
+		return err
+	}
+
+	logger.Info("STATUS: ROS 2 Bridge " + ros2Bridge.Name + " is updated.")
+	return nil
+}
+
+func (r *ROS2WorkloadReconciler) updateStatefulSet(ctx context.Context, instance *robotv1alpha2.ROS2Workload, key int) error {
+
+	node, err := r.reconcileGetNode(ctx, instance)
+	if err != nil {
+		return err
+	}
+
+	statefulSet := v1alpha2_resources.GetStatefulSet(instance, instance.GetStatefulSetMetadata(key), key, *node)
+
+	err = ctrl.SetControllerReference(instance, statefulSet, r.Scheme)
+	if err != nil {
+		return err
+	}
+
+	err = r.Update(ctx, statefulSet)
+	if err != nil && errors.IsAlreadyExists(err) {
+		return nil
+	} else if err != nil {
+		return err
+	}
+
+	logger.Info("STATUS: StatefulSet " + instance.GetStatefulSetMetadata(key).Name + " is updated.")
+	return nil
+}


### PR DESCRIPTION
# :herb: PR: Manage Lifecycle of StatefulSet(s) of ROS2Workload

## Description

- ROS2Workload controller creates stateful set(s) according to the API.
- Resources can be dynamically updated in runtime.

Closes #230 

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How can it be tested?

Can be tested with a sample manifest such as below:

```yaml
apiVersion: robot.roboscale.io/v1alpha2
kind: ROS2Workload
metadata:
  name: ros2-workload
  namespace: test
  labels:
    robolaunch.io/cloud-instance: org-development-16891285
    robolaunch.io/cloud-instance-alias: dev-ci-076
    robolaunch.io/domain: robolaunch.cloud
    robolaunch.io/organization: org_development
    robolaunch.io/platform: 0.1.2-prerelease.10
    robolaunch.io/region: eu-central-1
    robolaunch.io/team: org-development-16891285
    robolaunch.io/robot-image-registry: docker.io
spec:
  discoveryServerTemplate:
    type: Server
    hostname: "zzz"
    subdomain: "ttt"
    domainID: 0
  ros2BridgeTemplate:
    distro: humble
    discoveryServerRef:
      name: ros2-workload-discovery
      namespace: test
    serviceType: NodePort
    ingress: true
    tlsSecretName: prod-tls
  containers:
  - replicas: 1
    container:
      name: slam
      image: ubuntu:focal
      command: ["/bin/bash", "-c", "sleep infinity"]
      volumeMounts:
      - name: ros2-workload-pvc-0
        mountPath: /testing-mount
  - replicas: 1
    container:
      name: nav
      image: ubuntu:focal
      command: ["/bin/bash", "-c", "sleep infinity"]
      volumeMounts:
      - name: ros2-workload-pvc-0
        mountPath: /testing-mount
      resources:
        requests:
          memory: "64Mi"
          cpu: "250m"
        limits:
          memory: "128Mi"
          cpu: "500m"
      securityContext:
        privileged: true
  volumeClaimTemplates:
  - spec:
      accessModes:
      - ReadWriteOnce
      resources:
        limits:
          storage: 1Gi
        requests:
          storage: 1Gi
```
