### PR TITLE
PR: Select Protocol for Discovery Server

### DIFF
--- a/config/crd/bases/robot.roboscale.io_discoveryservers.yaml
+++ b/config/crd/bases/robot.roboscale.io_discoveryservers.yaml
@@ -74,6 +74,9 @@ spec:
                   value. If instance type is `Client`, it should be the same with
                   Server's hostname. Used for getting Server's IP over DNS.
                 type: string
+              protocol:
+                default: TCP
+                type: string
               reference:
                 description: Reference to the `Server` instance. It is used if `.spec.type`
                   is `Client`. Referenced object can be previously provisioned in

--- a/config/crd/bases/robot.roboscale.io_robotartifacts.yaml
+++ b/config/crd/bases/robot.roboscale.io_robotartifacts.yaml
@@ -119,6 +119,9 @@ spec:
                           with Server's hostname. Used for getting Server's IP over
                           DNS.
                         type: string
+                      protocol:
+                        default: TCP
+                        type: string
                       reference:
                         description: Reference to the `Server` instance. It is used
                           if `.spec.type` is `Client`. Referenced object can be previously

--- a/config/crd/bases/robot.roboscale.io_robots.yaml
+++ b/config/crd/bases/robot.roboscale.io_robots.yaml
@@ -140,6 +140,9 @@ spec:
                           with Server's hostname. Used for getting Server's IP over
                           DNS.
                         type: string
+                      protocol:
+                        default: TCP
+                        type: string
                       reference:
                         description: Reference to the `Server` instance. It is used
                           if `.spec.type` is `Client`. Referenced object can be previously

--- a/config/crd/bases/robot.roboscale.io_ros2workloads.yaml
+++ b/config/crd/bases/robot.roboscale.io_ros2workloads.yaml
@@ -35,7 +35,84 @@ spec:
           spec:
             description: Specification of the desired behavior of the ROS2Workload.
             properties:
-              containers:
+              discoveryServerTemplate:
+                description: Discovery server configurational parameters.
+                properties:
+                  cluster:
+                    description: Cloud instance name that holds DiscoveryServer instance
+                      with `Server` type. Should be empty if the type is `Server`
+                      since it takes cloud instance's name automatically. Should be
+                      set if the type is `Client`.
+                    type: string
+                  domainID:
+                    description: ROS domain ID for robot. See https://docs.ros.org/en/foxy/Concepts/About-Domain-ID.html.
+                    maximum: 101
+                    minimum: 0
+                    type: integer
+                  hostname:
+                    description: If instance type is `Server`, it can be an arbitrary
+                      value. If instance type is `Client`, it should be the same with
+                      Server's hostname. Used for getting Server's IP over DNS.
+                    type: string
+                  protocol:
+                    default: TCP
+                    type: string
+                  reference:
+                    description: Reference to the `Server` instance. It is used if
+                      `.spec.type` is `Client`. Referenced object can be previously
+                      provisioned in another cluster. In that case, cluster's name
+                      can be specified in `.spec.cluster` field.
+                    properties:
+                      apiVersion:
+                        description: API version of the referent.
+                        type: string
+                      fieldPath:
+                        description: 'If referring to a piece of an object instead
+                          of an entire object, this string should contain a valid
+                          JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                          For example, if the object reference is to a container within
+                          a pod, this would take on a value like: "spec.containers{name}"
+                          (where "name" refers to the name of the container that triggered
+                          the event) or if no container name is specified "spec.containers[2]"
+                          (container with index 2 in this pod). This syntax is chosen
+                          only to have some well-defined way of referencing a part
+                          of an object. TODO: this design is not final and this field
+                          is subject to change in the future.'
+                        type: string
+                      kind:
+                        description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                        type: string
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                        type: string
+                      namespace:
+                        description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                        type: string
+                      resourceVersion:
+                        description: 'Specific resourceVersion to which this reference
+                          is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                        type: string
+                      uid:
+                        description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                        type: string
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  subdomain:
+                    description: If instance type is `Server`, it can be an arbitrary
+                      value. If instance type is `Client`, it should be the same with
+                      Server's subdomain. Used for getting Server's IP over DNS.
+                    type: string
+                  type:
+                    description: Instance type can be either `Server` or `Client`.
+                      If `Server`, instance creates discovery server resources and
+                      workloads. Other `Client` instances can connect to the `Server`
+                      instance. If `Client`, instance tries to connect a `Server`
+                      instance and hold `Server` configuration in a ConfigMap.
+                    type: string
+                required:
+                - domainID
+                type: object
+              launchContainers:
                 description: Configurational parameters for containers that will be
                   encapsulated within the ROS 2 workload StatefulSet.
                 items:
@@ -1318,80 +1395,6 @@ spec:
                   - replicas
                   type: object
                 type: array
-              discoveryServerTemplate:
-                description: Discovery server configurational parameters.
-                properties:
-                  cluster:
-                    description: Cloud instance name that holds DiscoveryServer instance
-                      with `Server` type. Should be empty if the type is `Server`
-                      since it takes cloud instance's name automatically. Should be
-                      set if the type is `Client`.
-                    type: string
-                  domainID:
-                    description: ROS domain ID for robot. See https://docs.ros.org/en/foxy/Concepts/About-Domain-ID.html.
-                    maximum: 101
-                    minimum: 0
-                    type: integer
-                  hostname:
-                    description: If instance type is `Server`, it can be an arbitrary
-                      value. If instance type is `Client`, it should be the same with
-                      Server's hostname. Used for getting Server's IP over DNS.
-                    type: string
-                  reference:
-                    description: Reference to the `Server` instance. It is used if
-                      `.spec.type` is `Client`. Referenced object can be previously
-                      provisioned in another cluster. In that case, cluster's name
-                      can be specified in `.spec.cluster` field.
-                    properties:
-                      apiVersion:
-                        description: API version of the referent.
-                        type: string
-                      fieldPath:
-                        description: 'If referring to a piece of an object instead
-                          of an entire object, this string should contain a valid
-                          JSON/Go field access statement, such as desiredState.manifest.containers[2].
-                          For example, if the object reference is to a container within
-                          a pod, this would take on a value like: "spec.containers{name}"
-                          (where "name" refers to the name of the container that triggered
-                          the event) or if no container name is specified "spec.containers[2]"
-                          (container with index 2 in this pod). This syntax is chosen
-                          only to have some well-defined way of referencing a part
-                          of an object. TODO: this design is not final and this field
-                          is subject to change in the future.'
-                        type: string
-                      kind:
-                        description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                        type: string
-                      name:
-                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                        type: string
-                      namespace:
-                        description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                        type: string
-                      resourceVersion:
-                        description: 'Specific resourceVersion to which this reference
-                          is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                        type: string
-                      uid:
-                        description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
-                        type: string
-                    type: object
-                    x-kubernetes-map-type: atomic
-                  subdomain:
-                    description: If instance type is `Server`, it can be an arbitrary
-                      value. If instance type is `Client`, it should be the same with
-                      Server's subdomain. Used for getting Server's IP over DNS.
-                    type: string
-                  type:
-                    description: Instance type can be either `Server` or `Client`.
-                      If `Server`, instance creates discovery server resources and
-                      workloads. Other `Client` instances can connect to the `Server`
-                      instance. If `Client`, instance tries to connect a `Server`
-                      instance and hold `Server` configuration in a ConfigMap.
-                    type: string
-                required:
-                - domainID
-                type: object
               ros2BridgeTemplate:
                 description: ROS 2 Bridge configurational parameters.
                 properties:

--- a/internal/resources/v1alpha1/discovery_server.go
+++ b/internal/resources/v1alpha1/discovery_server.go
@@ -37,6 +37,7 @@ func GetDiscoveryServerPod(discoveryServer *robotv1alpha1.DiscoveryServer, podNa
 				{
 					Name:          discoveryServerPortName,
 					ContainerPort: int32(discoveryServerPortNumber),
+					Protocol:      discoveryServer.Spec.Protocol,
 				},
 			},
 		},
@@ -78,7 +79,7 @@ func GetDiscoveryServerService(discoveryServer *robotv1alpha1.DiscoveryServer, s
 					TargetPort: intstr.IntOrString{
 						IntVal: int32(discoveryServerPortNumber),
 					},
-					Protocol: corev1.ProtocolTCP,
+					Protocol: discoveryServer.Spec.Protocol,
 					Name:     discoveryServerPortName,
 				},
 			},

--- a/pkg/api/roboscale.io/v1alpha1/robot_types.go
+++ b/pkg/api/roboscale.io/v1alpha1/robot_types.go
@@ -415,6 +415,7 @@ const (
 
 // DiscoveryServerSpec defines the desired state of DiscoveryServer.
 type DiscoveryServerSpec struct {
+	Protocol corev1.Protocol `json:"protocol,omitempty"`
 	// ROS domain ID for robot. See https://docs.ros.org/en/foxy/Concepts/About-Domain-ID.html.
 	// +kubebuilder:validation:Minimum=0
 	// +kubebuilder:validation:Maximum=101


### PR DESCRIPTION
# :herb: PR: Select Protocol for Discovery Server

## Description

- User can choose discovery server protocol.

Closes #237 

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How can it be tested?
Can be tested by setting `.spec.protocol` field as `UDP` in DiscoveryServer manifest.
