### PR TITLE
PR: Enable Host Network on Request

### DIFF
--- a/internal/resources/v1alpha1/notebook.go
+++ b/internal/resources/v1alpha1/notebook.go
@@ -82,6 +82,13 @@ func GetNotebookPod(notebook *robotv1alpha1.Notebook, podNamespacedName *types.N
 	if ports, ok := robot.Spec.AdditionalConfigs[internal.NOTEBOOK_CUSTOM_PORT_RANGE_KEY]; ok {
 		containerCfg.InjectCustomPortConfiguration(&nbContainer, ports)
 	}
+	// apply host network selection
+	useHostNetwork := false
+	if hostNetwork, ok := robot.Spec.AdditionalConfigs[internal.HOST_NETWORK_SELECTION_KEY]; ok {
+		if hostNetwork.Value == "true" {
+			useHostNetwork = true
+		}
+	}
 
 	nbPod := corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -90,7 +97,7 @@ func GetNotebookPod(notebook *robotv1alpha1.Notebook, podNamespacedName *types.N
 			Labels:    labels,
 		},
 		Spec: corev1.PodSpec{
-			// HostNetwork: notebook.Spec.Privileged,
+			HostNetwork: useHostNetwork,
 			Containers: []corev1.Container{
 				nbContainer,
 			},

--- a/internal/resources/v1alpha1/robot_ide.go
+++ b/internal/resources/v1alpha1/robot_ide.go
@@ -82,6 +82,14 @@ func GetRobotIDEPod(robotIDE *robotv1alpha1.RobotIDE, podNamespacedName *types.N
 		containerCfg.InjectCustomPortConfiguration(&ideContainer, ports)
 	}
 
+	// apply host network selection
+	useHostNetwork := false
+	if hostNetwork, ok := robot.Spec.AdditionalConfigs[internal.HOST_NETWORK_SELECTION_KEY]; ok {
+		if hostNetwork.Value == "true" {
+			useHostNetwork = true
+		}
+	}
+
 	idePod := corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      podNamespacedName.Name,
@@ -89,7 +97,7 @@ func GetRobotIDEPod(robotIDE *robotv1alpha1.RobotIDE, podNamespacedName *types.N
 			Labels:    labels,
 		},
 		Spec: corev1.PodSpec{
-			// HostNetwork: robotIDE.Spec.Privileged,
+			HostNetwork: useHostNetwork,
 			Containers: []corev1.Container{
 				ideContainer,
 			},

--- a/internal/resources/v1alpha1/robot_vdi.go
+++ b/internal/resources/v1alpha1/robot_vdi.go
@@ -141,6 +141,13 @@ func GetRobotVDIPod(robotVDI *robotv1alpha1.RobotVDI, podNamespacedName *types.N
 	if ports, ok := robot.Spec.AdditionalConfigs[internal.VDI_CUSTOM_PORT_RANGE_KEY]; ok {
 		containerCfg.InjectCustomPortConfiguration(&vdiContainer, ports)
 	}
+	// apply host network selection
+	useHostNetwork := false
+	if hostNetwork, ok := robot.Spec.AdditionalConfigs[internal.HOST_NETWORK_SELECTION_KEY]; ok {
+		if hostNetwork.Value == "true" {
+			useHostNetwork = true
+		}
+	}
 
 	vdiPod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -149,7 +156,7 @@ func GetRobotVDIPod(robotVDI *robotv1alpha1.RobotVDI, podNamespacedName *types.N
 			Labels:    labels,
 		},
 		Spec: corev1.PodSpec{
-			// HostNetwork: robotVDI.Spec.Privileged,
+			HostNetwork: useHostNetwork,
 			Containers: []corev1.Container{
 				vdiContainer,
 			},

--- a/internal/shared.go
+++ b/internal/shared.go
@@ -176,15 +176,17 @@ const (
 	VDI_CUSTOM_PORT_RANGE_KEY      = "VDI_CUSTOM_PORT_RANGE"
 	NOTEBOOK_CUSTOM_PORT_RANGE_KEY = "NOTEBOOK_CUSTOM_PORT_RANGE"
 	SHARED_MEMORY_SIZE_KEY         = "SHARED_MEMORY_SIZE"
+	HOST_NETWORK_SELECTION_KEY     = "USE_HOST_NETWORK"
 )
 
 // regex
 const (
-	GRANT_PERMISSION_REGEX   = "^(/([A-Za-z0-9./_-])+:)*(/[A-Za-z0-9./_-]+)$"
-	PERSISTENT_DIRS_REGEX    = "^(/([A-Za-z0-9./_-])+:)*(/[A-Za-z0-9./_-]+)$"
-	HOST_DIRS_REGEX          = "^(((/[A-Za-z0-9./_-]+):(/[A-Za-z0-9./_-]+))+,)*(((/[A-Za-z0-9./_-]+):(/[A-Za-z0-9./_-]+))+)$"
-	CUSTOM_PORT_RANGE_REGEX  = "^([a-z0-9]{4}-[0-9]{5}:[0-9]{2,5}/)*([a-z0-9]{4}-[0-9]{5}:[0-9]{2,5})$"
-	SHARED_MEMORY_SIZE_REGEX = "^([0-9]{1,2}Gi)$"
+	GRANT_PERMISSION_REGEX       = "^(/([A-Za-z0-9./_-])+:)*(/[A-Za-z0-9./_-]+)$"
+	PERSISTENT_DIRS_REGEX        = "^(/([A-Za-z0-9./_-])+:)*(/[A-Za-z0-9./_-]+)$"
+	HOST_DIRS_REGEX              = "^(((/[A-Za-z0-9./_-]+):(/[A-Za-z0-9./_-]+))+,)*(((/[A-Za-z0-9./_-]+):(/[A-Za-z0-9./_-]+))+)$"
+	CUSTOM_PORT_RANGE_REGEX      = "^([a-z0-9]{4}-[0-9]{5}:[0-9]{2,5}/)*([a-z0-9]{4}-[0-9]{5}:[0-9]{2,5})$"
+	SHARED_MEMORY_SIZE_REGEX     = "^([0-9]{1,2}Gi)$"
+	HOST_NETWORK_SELECTION_REGEX = "^(true|false)$"
 )
 
 // file browser ports

--- a/pkg/api/roboscale.io/v1alpha1/robot_webhook.go
+++ b/pkg/api/roboscale.io/v1alpha1/robot_webhook.go
@@ -280,6 +280,16 @@ func (r *Robot) checkAdditionalConfigs() error {
 		}
 	}
 
+	if val, ok := r.Spec.AdditionalConfigs[internal.HOST_NETWORK_SELECTION_KEY]; ok && val.ConfigType == AdditionalConfigTypeOperator {
+		matched, err := regexp.MatchString(internal.HOST_NETWORK_SELECTION_REGEX, val.Value)
+		if !matched {
+			return errors.New("cannot set host network, use this pattern " + internal.HOST_NETWORK_SELECTION_REGEX)
+		}
+		if err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
# :herb: PR: Enable Host Network on Request

## Description

Host network is disabled by default for IDE, VDI and notebook pods. It can be enabled by setting the config with type `Operator` and key `USE_HOST_NETWORK`. Here is the regex for the config value:
- `^(true|false)$`

Closes #247 

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How can it be tested?

Can be tested by setting an additional config as below:

```yaml
spec:
  additionalConfigs:
    USE_HOST_NETWORK:
      configType: Operator
      value: "true"
```
