### PR TITLE
PR: Specify Application/File Browser Ports for Internal Apps

### DIFF
--- a/internal/resources/v1alpha1/notebook.go
+++ b/internal/resources/v1alpha1/notebook.go
@@ -19,8 +19,8 @@ import (
 )
 
 const (
-	NOTEBOOK_PORT_NAME = "notebook"
-	NOTEBOOK_PORT      = 8888
+	NOTEBOOK_PORT_NAME    = "notebook"
+	DEFAULT_NOTEBOOK_PORT = 8888
 )
 
 func getNotebookSelector(notebook robotv1alpha1.Notebook) map[string]string {
@@ -48,7 +48,7 @@ func GetNotebookPod(notebook *robotv1alpha1.Notebook, podNamespacedName *types.N
 		Image:   robot.Status.Image,
 		Command: internal.Bash(cmdBuilder.String()),
 		Env: []corev1.EnvVar{
-			internal.Env("NOTEBOOK_PORT", strconv.Itoa(NOTEBOOK_PORT)),
+			internal.Env("NOTEBOOK_PORT", strconv.Itoa(DEFAULT_NOTEBOOK_PORT)),
 			internal.Env("NOTEBOOK_BASE_URL", robotv1alpha1.GetRobotServicePath(robot, "/notebook")),
 			internal.Env("FILE_BROWSER_PORT", strconv.Itoa(internal.FILE_BROWSER_PORT)),
 			internal.Env("FILE_BROWSER_SERVICE", "notebook"),
@@ -61,7 +61,7 @@ func GetNotebookPod(notebook *robotv1alpha1.Notebook, podNamespacedName *types.N
 		Ports: []corev1.ContainerPort{
 			{
 				Name:          NOTEBOOK_PORT_NAME,
-				ContainerPort: NOTEBOOK_PORT,
+				ContainerPort: DEFAULT_NOTEBOOK_PORT,
 			},
 			{
 				Name:          internal.FILE_BROWSER_PORT_NAME,
@@ -136,9 +136,9 @@ func GetNotebookService(notebook *robotv1alpha1.Notebook, svcNamespacedName *typ
 		Selector: getNotebookSelector(*notebook),
 		Ports: []corev1.ServicePort{
 			{
-				Port: NOTEBOOK_PORT,
+				Port: DEFAULT_NOTEBOOK_PORT,
 				TargetPort: intstr.IntOrString{
-					IntVal: NOTEBOOK_PORT,
+					IntVal: DEFAULT_NOTEBOOK_PORT,
 				},
 				Protocol: corev1.ProtocolTCP,
 				Name:     NOTEBOOK_PORT_NAME,
@@ -212,7 +212,7 @@ func GetNotebookIngress(notebook *robotv1alpha1.Notebook, ingressNamespacedName 
 									Service: &networkingv1.IngressServiceBackend{
 										Name: notebook.GetNotebookServiceMetadata().Name,
 										Port: networkingv1.ServiceBackendPort{
-											Number: NOTEBOOK_PORT,
+											Number: DEFAULT_NOTEBOOK_PORT,
 										},
 									},
 								},

--- a/internal/resources/v1alpha1/robot_ide.go
+++ b/internal/resources/v1alpha1/robot_ide.go
@@ -19,8 +19,8 @@ import (
 )
 
 const (
-	ROBOT_IDE_PORT_NAME = "code-server"
-	ROBOT_IDE_PORT      = 9000
+	ROBOT_IDE_PORT_NAME    = "code-server"
+	DEFAULT_ROBOT_IDE_PORT = 9000
 )
 
 func getRobotIDESelector(robotIDE robotv1alpha1.RobotIDE) map[string]string {
@@ -48,7 +48,7 @@ func GetRobotIDEPod(robotIDE *robotv1alpha1.RobotIDE, podNamespacedName *types.N
 		Image:   robot.Status.Image,
 		Command: internal.Bash(cmdBuilder.String()),
 		Env: []corev1.EnvVar{
-			internal.Env("CODE_SERVER_PORT", strconv.Itoa(ROBOT_IDE_PORT)),
+			internal.Env("CODE_SERVER_PORT", strconv.Itoa(DEFAULT_ROBOT_IDE_PORT)),
 			internal.Env("FILE_BROWSER_PORT", strconv.Itoa(internal.FILE_BROWSER_PORT)),
 			internal.Env("FILE_BROWSER_SERVICE", "code-server"),
 			internal.Env("FILE_BROWSER_BASE_URL", robotv1alpha1.GetRobotServicePath(robot, "/file-browser/ide")),
@@ -60,7 +60,7 @@ func GetRobotIDEPod(robotIDE *robotv1alpha1.RobotIDE, podNamespacedName *types.N
 		Ports: []corev1.ContainerPort{
 			{
 				Name:          ROBOT_IDE_PORT_NAME,
-				ContainerPort: ROBOT_IDE_PORT,
+				ContainerPort: DEFAULT_ROBOT_IDE_PORT,
 			},
 			{
 				Name:          internal.FILE_BROWSER_PORT_NAME,
@@ -147,9 +147,9 @@ func GetRobotIDEService(robotIDE *robotv1alpha1.RobotIDE, svcNamespacedName *typ
 		Selector: getRobotIDESelector(*robotIDE),
 		Ports: []corev1.ServicePort{
 			{
-				Port: ROBOT_IDE_PORT,
+				Port: DEFAULT_ROBOT_IDE_PORT,
 				TargetPort: intstr.IntOrString{
-					IntVal: ROBOT_IDE_PORT,
+					IntVal: DEFAULT_ROBOT_IDE_PORT,
 				},
 				Protocol: corev1.ProtocolTCP,
 				Name:     ROBOT_IDE_PORT_NAME,
@@ -225,7 +225,7 @@ func GetRobotIDEIngress(robotIDE *robotv1alpha1.RobotIDE, ingressNamespacedName 
 									Service: &networkingv1.IngressServiceBackend{
 										Name: robotIDE.GetRobotIDEServiceMetadata().Name,
 										Port: networkingv1.ServiceBackendPort{
-											Number: ROBOT_IDE_PORT,
+											Number: DEFAULT_ROBOT_IDE_PORT,
 										},
 									},
 								},

--- a/internal/resources/v1alpha1/robot_vdi.go
+++ b/internal/resources/v1alpha1/robot_vdi.go
@@ -37,6 +37,14 @@ func getRobotVDIInternalAppPort(robotVDI robotv1alpha1.RobotVDI) int {
 	return DEFAULT_ROBOT_VDI_PORT
 }
 
+func getRobotVDIFBInternalAppPort(robotVDI robotv1alpha1.RobotVDI) int {
+	if val, ok := robotVDI.Labels[internal.ROBOT_VDI_FB_PORT_KEY]; ok {
+		portInt, _ := strconv.Atoi(val)
+		return portInt
+	}
+	return internal.FILE_BROWSER_PORT
+}
+
 func GetRobotVDIPVC(robotVDI *robotv1alpha1.RobotVDI, pvcNamespacedName *types.NamespacedName, robot robotv1alpha1.Robot) *corev1.PersistentVolumeClaim {
 
 	pvc := corev1.PersistentVolumeClaim{
@@ -77,7 +85,7 @@ func GetRobotVDIPod(robotVDI *robotv1alpha1.RobotVDI, podNamespacedName *types.N
 		},
 		{
 			Name:          internal.FILE_BROWSER_PORT_NAME,
-			ContainerPort: internal.FILE_BROWSER_PORT,
+			ContainerPort: int32(getRobotVDIFBInternalAppPort(*robotVDI)),
 			Protocol:      corev1.ProtocolTCP,
 		},
 	}
@@ -123,7 +131,7 @@ func GetRobotVDIPod(robotVDI *robotv1alpha1.RobotVDI, podNamespacedName *types.N
 			internal.Env("NEKO_ICELITE", icelite),
 			internal.Env("NEKO_NAT1TO1", robotVDI.Spec.NAT1TO1),
 			internal.Env("RESOLUTION", robotVDI.Spec.Resolution),
-			internal.Env("FILE_BROWSER_PORT", strconv.Itoa(internal.FILE_BROWSER_PORT)),
+			internal.Env("FILE_BROWSER_PORT", strconv.Itoa(getRobotVDIFBInternalAppPort(*robotVDI))),
 			internal.Env("FILE_BROWSER_SERVICE", "vdi"),
 			internal.Env("FILE_BROWSER_BASE_URL", robotv1alpha1.GetRobotServicePath(robot, "/file-browser/vdi")),
 		},
@@ -215,9 +223,9 @@ func GetRobotVDIServiceTCP(robotVDI *robotv1alpha1.RobotVDI, svcNamespacedName *
 			Name:     ROBOT_VDI_PORT_NAME,
 		},
 		{
-			Port: internal.FILE_BROWSER_PORT,
+			Port: int32(getRobotVDIFBInternalAppPort(*robotVDI)),
 			TargetPort: intstr.IntOrString{
-				IntVal: int32(internal.FILE_BROWSER_PORT),
+				IntVal: int32(getRobotVDIFBInternalAppPort(*robotVDI)),
 			},
 			Protocol: corev1.ProtocolTCP,
 			Name:     internal.FILE_BROWSER_PORT_NAME,
@@ -339,7 +347,7 @@ func GetRobotVDIIngress(robotVDI *robotv1alpha1.RobotVDI, ingressNamespacedName 
 									Service: &networkingv1.IngressServiceBackend{
 										Name: robotVDI.GetRobotVDIServiceTCPMetadata().Name,
 										Port: networkingv1.ServiceBackendPort{
-											Number: int32(internal.FILE_BROWSER_PORT),
+											Number: int32(getRobotVDIFBInternalAppPort(*robotVDI)),
 										},
 									},
 								},

--- a/internal/resources/v1alpha1/robot_vdi.go
+++ b/internal/resources/v1alpha1/robot_vdi.go
@@ -19,8 +19,8 @@ import (
 )
 
 const (
-	ROBOT_VDI_PORT_NAME = "http"
-	ROBOT_VDI_PORT      = 8055
+	ROBOT_VDI_PORT_NAME    = "http"
+	DEFAULT_ROBOT_VDI_PORT = 8055
 )
 
 func getRobotVDISelector(robotVDI robotv1alpha1.RobotVDI) map[string]string {
@@ -64,7 +64,7 @@ func GetRobotVDIPod(robotVDI *robotv1alpha1.RobotVDI, podNamespacedName *types.N
 	ports := []corev1.ContainerPort{
 		{
 			Name:          ROBOT_VDI_PORT_NAME,
-			ContainerPort: ROBOT_VDI_PORT,
+			ContainerPort: DEFAULT_ROBOT_VDI_PORT,
 			Protocol:      corev1.ProtocolTCP,
 		},
 		{
@@ -199,9 +199,9 @@ func GetRobotVDIServiceTCP(robotVDI *robotv1alpha1.RobotVDI, svcNamespacedName *
 
 	ports := []corev1.ServicePort{
 		{
-			Port: ROBOT_VDI_PORT,
+			Port: DEFAULT_ROBOT_VDI_PORT,
 			TargetPort: intstr.IntOrString{
-				IntVal: int32(ROBOT_VDI_PORT),
+				IntVal: int32(DEFAULT_ROBOT_VDI_PORT),
 			},
 			Protocol: corev1.ProtocolTCP,
 			Name:     ROBOT_VDI_PORT_NAME,
@@ -319,7 +319,7 @@ func GetRobotVDIIngress(robotVDI *robotv1alpha1.RobotVDI, ingressNamespacedName 
 									Service: &networkingv1.IngressServiceBackend{
 										Name: robotVDI.GetRobotVDIServiceTCPMetadata().Name,
 										Port: networkingv1.ServiceBackendPort{
-											Number: int32(ROBOT_VDI_PORT),
+											Number: int32(DEFAULT_ROBOT_VDI_PORT),
 										},
 									},
 								},

--- a/internal/shared.go
+++ b/internal/shared.go
@@ -60,6 +60,11 @@ const (
 	NOTEBOOK_FB_PORT_KEY  = "robolaunch.io/notebook-port"
 )
 
+// Special escape label regex
+const (
+	INTERNAL_APP_PORT_REGEX = "^[0-9]{4,5}$"
+)
+
 // Platform server
 const (
 	DEFAULT_PLATFORM_URL           = "https://raw.githubusercontent.com/robolaunch/platform/main/platforms/industry-cloud-platform/platform.yaml"

--- a/internal/shared.go
+++ b/internal/shared.go
@@ -52,6 +52,12 @@ const (
 // Special escape labels
 const (
 	ROBOT_DEV_SUITE_OWNED = "robolaunch.io/dev-suite-owned"
+	ROBOT_IDE_PORT_KEY    = "robolaunch.io/ide-port"
+	ROBOT_VDI_PORT_KEY    = "robolaunch.io/vdi-port"
+	NOTEBOOK_PORT_KEY     = "robolaunch.io/notebook-port"
+	ROBOT_IDE_FB_PORT_KEY = "robolaunch.io/ide-port"
+	ROBOT_VDI_FB_PORT_KEY = "robolaunch.io/vdi-port"
+	NOTEBOOK_FB_PORT_KEY  = "robolaunch.io/notebook-port"
 )
 
 // Platform server

--- a/internal/shared.go
+++ b/internal/shared.go
@@ -55,9 +55,9 @@ const (
 	ROBOT_IDE_PORT_KEY    = "robolaunch.io/ide-port"
 	ROBOT_VDI_PORT_KEY    = "robolaunch.io/vdi-port"
 	NOTEBOOK_PORT_KEY     = "robolaunch.io/notebook-port"
-	ROBOT_IDE_FB_PORT_KEY = "robolaunch.io/ide-port"
-	ROBOT_VDI_FB_PORT_KEY = "robolaunch.io/vdi-port"
-	NOTEBOOK_FB_PORT_KEY  = "robolaunch.io/notebook-port"
+	ROBOT_IDE_FB_PORT_KEY = "robolaunch.io/ide-fb-port"
+	ROBOT_VDI_FB_PORT_KEY = "robolaunch.io/vdi-fb-port"
+	NOTEBOOK_FB_PORT_KEY  = "robolaunch.io/notebook-fb-port"
 )
 
 // Special escape label regex


### PR DESCRIPTION
# :herb: PR: Specify Application/File Browser Ports for Internal Apps

## Description

- New labels are defined for `RobotIDE`, `RobotVDI` and `Notebook`.
  - `robolaunch.io/ide-port` - for `RobotIDE`
  - `robolaunch.io/vdi-port` - for `RobotVDI`
  - `robolaunch.io/notebook-port` - for `Notebook`
  - `robolaunch.io/ide-fb-port` - for `RobotIDE`
  - `robolaunch.io/vdi-fb-port` - for `RobotVDI`
  - `robolaunch.io/notebook-fb-port` - for `Notebook`

Closes #249 

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How can it be tested?

Can be tested by adding labels to the corresponding custom resources.
